### PR TITLE
New  registry entry for 'Unique Tax Identification Code (Argentina)' (AR-CUIT)

### DIFF
--- a/lists/ar/ar-cuit.json
+++ b/lists/ar/ar-cuit.json
@@ -17,8 +17,9 @@
   ],
   "sector": [],
   "code": "AR-CUIT",
-  "confirmed": false,
+  "confirmed": true,
   "deprecated": false,
+  "listType": "secondary",
   "access": {
     "onlineAccessDetails": "Third party search services such as https://www.dateas.com/es/consulta_cuit_cuil exist and provide name based search of CUIT (tax identifier) and CUIL (labour identifier).",
     "publicDatabase": "http://www.afip.gob.ar/futCont/",
@@ -35,8 +36,8 @@
       "industry_classifications",
       "status"
     ],
-    "licenseDetails": "",
-    "licenseStatus": "no_license"
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
   },
   "meta": {
     "source": "Open Contracting",
@@ -47,6 +48,5 @@
     "wikipedia": ""
   },
   "formerPrefixes": [],
-  "listType": "secondary",
   "License": null
 }

--- a/lists/ar/ar-cuit.json
+++ b/lists/ar/ar-cuit.json
@@ -1,0 +1,52 @@
+{
+  "name": {
+    "en": "Unique Tax Identification Code (Argentina)",
+    "local": "Clave Única Identificación Tributaria (Argentina)"
+  },
+  "url": "",
+  "description": {
+    "en": "Any citizen or company starting an economic activity in Argentina must register with the AFIP (Federal Administration of Public Revenues) and receive a Unique Tax Identification Code (CUIT). \n\nThis is an 11 digit number, consisting two digits, hyphen, nine digits, and a one digit checksum. \n"
+  },
+  "coverage": [
+    "AR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "company",
+    "unincorporated_body"
+  ],
+  "sector": [],
+  "code": "AR-CUIT",
+  "confirmed": false,
+  "deprecated": false,
+  "access": {
+    "onlineAccessDetails": "Third party search services such as https://www.dateas.com/es/consulta_cuit_cuil exist and provide name based search of CUIT (tax identifier) and CUIL (labour identifier).",
+    "publicDatabase": "http://www.afip.gob.ar/futCont/",
+    "guidanceOnLocatingIds": "Use a third-party service to search for identifiers. Identifiers can be verified at http://www.afip.gob.ar/futCont/",
+    "exampleIdentifiers": "30-69330706-2, 30-70737344-6",
+    "languages": [
+      "es"
+    ]
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "",
+    "features": [
+      "industry_classifications",
+      "status"
+    ],
+    "licenseDetails": "",
+    "licenseStatus": "no_license"
+  },
+  "meta": {
+    "source": "Open Contracting",
+    "lastUpdated": "2017-06-26"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": [],
+  "listType": "secondary",
+  "License": null
+}


### PR DESCRIPTION
A new list has been proposed with the code AR-CUIT

**List title:** Unique Tax Identification Code (Argentina)

 Preview the platform with this list at [http://org-id.guide/_preview_branch/AR-CUIT](http://org-id.guide/_preview_branch/AR-CUIT)  (visiting [http://org-id.guide/list/AR-CUIT](http://org-id.guide/list/AR-CUIT) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.