### PR TITLE
Updated  registry entry for 'Local Authorities for England Register' (GB-LAE)

### DIFF
--- a/lists/gb/gb-lae.json
+++ b/lists/gb/gb-lae.json
@@ -14,7 +14,8 @@
     "GB-ENG"
   ],
   "structure": [
-    "government_agency/local_government"
+    "government_agency/local_government",
+    "government_agency"
   ],
   "sector": [],
   "code": "GB-LAE",
@@ -24,7 +25,7 @@
   "access": {
     "availableOnline": true,
     "onlineAccessDetails": null,
-    "publicDatabase": "http://local-authority-eng.alpha.openregister.org/",
+    "publicDatabase": "https://local-authority-eng.register.gov.uk/records",
     "guidanceOnLocatingIds": "Look for the value of the 'Local-authority-eng' field. ",
     "exampleIdentifiers": "WOT, BAS, GED",
     "languages": [

--- a/lists/gb/gb-lae.json
+++ b/lists/gb/gb-lae.json
@@ -3,7 +3,7 @@
     "en": "Local Authorities for England Register",
     "local": ""
   },
-  "url": "http://local-authority-eng.alpha.openregister.org/records",
+  "url": "https://local-authority-eng.register.gov.uk/records",
   "description": {
     "en": "The Local Authorities for England Register has been developed with the UK Department for Communities and Local Government (DCLG), and contains identifiers for 350+ local authorities. \n\nIt uses the second portion of '[ISO_3166-2](https://en.wikipedia.org/wiki/ISO_3166-2:GB)' codes where these are available, and creates new codes where they are not. "
   },


### PR DESCRIPTION
An update to the list with code GB-LAE has been proposed

**List title:** Local Authorities for England Register

 Preview the platform with this list at [http://org-id.guide/_preview_branch/GB-LAE](http://org-id.guide/_preview_branch/GB-LAE)  (visiting [http://org-id.guide/list/GB-LAE](http://org-id.guide/list/GB-LAE) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.