### PR TITLE
Updated  registry entry for 'OECD Development Assistance Committee' (XM-DAC)

### DIFF
--- a/lists/xm/xm-dac.json
+++ b/lists/xm/xm-dac.json
@@ -1,53 +1,50 @@
 {
-    "links": {
-        "wikipedia": null,
-        "opencorporates": null
-    },
-    "sector": null,
-    "url": "http://www.oecd.org/dac/stats/dacandcrscodelists.htm",
-    "name": {
-        "en": "OECD Development Assistance Committee",
-        "local": ""
-    },
-    "coverage": null,
-    "code": "XM-DAC",
-    "formerPrefixes": null,
-    "confirmed": true,
-    "data": {
-        "features": [
-            "organisation_name"
-        ],
-        "dataAccessDetails": "Data is available in Excel file that contains much formatting.",
-        "licenseDetails": null,
-        "licenseStatus": "no_license",
-        "availability": [
-            "excel"
-        ]
-    },
-    "deprecated": null,
-    "structure": [
-        "company",
-        "government_agency",
-        "charity"
+  "name": {
+    "en": "OECD Development Assistance Committee",
+    "local": ""
+  },
+  "url": "http://www.oecd.org/dac/stats/dacandcrscodelists.htm",
+  "description": {
+    "en": "The Organisation for Economic Co-operation and Development (OECD) Development Assistance Committee (DAC) has created a list of organisations whom are involved in the transfer of financial flows within the work of the OECD DAC. A list of all the Donors, Agencies and Recipients can be downloaded from the OECD website. This list is updated every three years.\n\nSee Donor, Agency and Delivery Channel codes.\n\n\"The overarching objective of the DAC for 2011-2015  is to promote development co-operation and other policies so as to contribute to sustainable development, including pro-poor economic growth, poverty reduction, improvement of living standards in developing countries, and to a future in which no country will depend on aid.\" [1]\n\n\"The DAC revises the list every three years. Countries that have exceeded the high-income threshold for three consecutive years at the time of the review are removed.\" [2] \n\n[1] http://www.oecd.org/dac/thedevelopmentassistancecommitteesmandate.htm\n[2] http://www.oecd.org/dac/stats/daclist.htm"
+  },
+  "coverage": [],
+  "subnationalCoverage": [],
+  "structure": [
+    "company",
+    "government_agency",
+    "charity"
+  ],
+  "sector": [],
+  "code": "XM-DAC",
+  "confirmed": true,
+  "deprecated": false,
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": null,
+    "publicDatabase": "http://www.oecd.org/dac/stats/dacandcrscodelists.htm",
+    "guidanceOnLocatingIds": "Users can download an Excel file of the DAC and CRS codes from the OECD website. Organisation identifiers can be found in the tabs 'See Donor', 'Agency' and 'Delivery Channel' codes. Identifiers will be under 'Donor code' and 'Channel ID' respectively.\n\nUsers should not that the data is available in a Excel file that contains much formatting.",
+    "exampleIdentifiers": "7, 104, 914, 1312",
+    "languages": [
+      "en",
+      "fr"
+    ]
+  },
+  "data": {
+    "availability": [
+      "excel"
     ],
-    "description": {
-        "en": "The Organisation for Economic Co-operation and Development (OECD) Development Assistance Committee (DAC) has created a list of organisations whom are involved in the transfer of financial flows within the work of the OECD DAC. A list of all the Donors, Agencies and Recipients can be downloaded from the OECD website. This list is updated every three years.\n\nSee Donor, Agency and Delivery Channel codes.\n\n\"The overarching objective of the DAC for 2011-2015  is to promote development co-operation and other policies so as to contribute to sustainable development, including pro-poor economic growth, poverty reduction, improvement of living standards in developing countries, and to a future in which no country will depend on aid.\" [1]\n\n\"The DAC revises the list every three years. Countries that have exceeded the high-income threshold for three consecutive years at the time of the review are removed.\" [2] \n\n[1] http://www.oecd.org/dac/thedevelopmentassistancecommitteesmandate.htm\n[2] http://www.oecd.org/dac/stats/daclist.htm"
-    },
-    "meta": {
-        "lastUpdated": "2016-12-27",
-        "source": "Desk research"
-    },
-    "access": {
-        "languages": [
-            "en",
-            "fr"
-        ],
-        "exampleIdentifiers": "7, 104, 914, 1312",
-        "onlineAccessDetails": null,
-        "publicDatabase": "http://www.oecd.org/dac/stats/dacandcrscodelists.htm / http://www.oecd.org/dac/stats/documentupload/Codelist_July_2016.xls",
-        "availableOnline": false,
-        "guidanceOnLocatingIds": "Users can download an Excel file of the DAC and CRS codes from the OECD website. Organisation identifiers can be found in the tabs 'See Donor', 'Agency' and 'Delivery Channel' codes. Identifiers will be under 'Donor code' and 'Channel ID' respectively.\n\nUsers should not that the data is available in a Excel file that contains much formatting."
-    },
-    "subnationalCoverage": null,
-    "listType": "third-party"
+    "dataAccessDetails": "Data is available in Excel file that contains much formatting.",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2016-12-27"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
 }


### PR DESCRIPTION
An update to the list with code XM-DAC has been proposed

**List title:** OECD Development Assistance Committee

 Preview the platform with this list at [http://org-id.guide/_preview_branch/XM-DAC](http://org-id.guide/_preview_branch/XM-DAC)  (visiting [http://org-id.guide/list/XM-DAC](http://org-id.guide/list/XM-DAC) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.