### PR TITLE
New  registry entry for 'South Sudan Relief and Rehabilitation Commission' (SS-RRC)

### DIFF
--- a/lists/ss/ss-rrc.json
+++ b/lists/ss/ss-rrc.json
@@ -1,0 +1,50 @@
+{
+  "name": {
+    "en": "South Sudan Relief and Rehabilitation Commission",
+    "local": ""
+  },
+  "url": "",
+  "description": {
+    "en": "The South Sudan Relief and Rehabilitation Commission (SSRRC) is an agency of the Government of South Sudan. It is the operational arm of the Ministry of Humanitarian Affairs and Disaster Management. The NGO Act 2016 added additional powers to the agency to register any NGO interested in operating in South Sudan. "
+  },
+  "coverage": [
+    "SS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity"
+  ],
+  "sector": [],
+  "code": "SS-RRC",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "Ask organisations registered with the South Sudan Relief and Rehabilitation Commission for their registration number. ",
+    "exampleIdentifiers": "",
+    "languages": [
+      ""
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "IATI",
+    "lastUpdated": "2017-08-05"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": "https://en.wikipedia.org/wiki/South_Sudan_Relief_and_Rehabilitation_Commission"
+  },
+  "formerPrefixes": []
+}


### PR DESCRIPTION
A new list has been proposed with the code SS-RRC

**List title:** South Sudan Relief and Rehabilitation Commission

 Preview the platform with this list at [http://org-id.guide/_preview_branch/SS-RRC](http://org-id.guide/_preview_branch/SS-RRC)  (visiting [http://org-id.guide/list/SS-RRC](http://org-id.guide/list/SS-RRC) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.