### PR TITLE
New  registry entry for 'Ministry of Interior (Lebanon)' (LB-MOI)

### DIFF
--- a/lists/lb/lb-moi.json
+++ b/lists/lb/lb-moi.json
@@ -1,0 +1,50 @@
+{
+  "name": {
+    "en": "Ministry of Interior (Lebanon)",
+    "local": ""
+  },
+  "url": "http://www.interior.gov.lb/",
+  "description": {
+    "en": "The Ministry of Interior is the main registration body in Lebanon. All NGOs are required to register with the Ministry of Interior."
+  },
+  "coverage": [
+    "LB"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity"
+  ],
+  "sector": [],
+  "code": "LB-MOI",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "No online list could be located.",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "Ask organisations for their registration number, as issued by the Ministry of Interior. ",
+    "exampleIdentifiers": "",
+    "languages": [
+      "ar"
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "IATI",
+    "lastUpdated": "2017-08-05"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}


### PR DESCRIPTION
A new list has been proposed with the code LB-MOI

**List title:** Ministry of Interior (Lebanon)

 Preview the platform with this list at [http://org-id.guide/_preview_branch/LB-MOI](http://org-id.guide/_preview_branch/LB-MOI)  (visiting [http://org-id.guide/list/LB-MOI](http://org-id.guide/list/LB-MOI) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.