### PR TITLE
New  registry entry for 'Economic Operators Identification and Registration system' (XI-EORI)

### DIFF
--- a/lists/xi/xi-eori.json
+++ b/lists/xi/xi-eori.json
@@ -1,0 +1,50 @@
+{
+  "name": {
+    "en": "Economic Operators Identification and Registration system",
+    "local": ""
+  },
+  "url": "http://ec.europa.eu/taxation_customs/dds2/eos/eori_validation.jsp",
+  "description": {
+    "en": "This site allows to validate EORI numbers and provides access to the information related to Authorised Economic Operators (AEO). An EORI number is unique throughout the EU, assigned by a customs authority in a member state to economic operators (businesses) or persons. "
+  },
+  "coverage": [
+    "XI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "company",
+    "charity"
+  ],
+  "sector": [],
+  "code": "XI-EORI",
+  "confirmed": true,
+  "deprecated": false,
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": null,
+    "publicDatabase": "http://ec.europa.eu/taxation_customs/business/calculation-customs-duties/rules-origin/general-aspects-preferential-origin/arrangements-list/generalised-system-preferences/the_register_exporter_system_en",
+    "guidanceOnLocatingIds": "An EORI number must start with two uppercase letters (the ISO code of the country that granted the number) followed by maximum 15 alphanumeric characters",
+    "exampleIdentifiers": "NL810656371",
+    "languages": []
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "",
+    "lastUpdated": "2017-07-18"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": [],
+  "registerType": "",
+  "listType": "secondary"
+}


### PR DESCRIPTION
A new list has been proposed with the code XI-EORI

**List title:** Economic Operators Identification and Registration system

 Preview the platform with this list at [http://org-id.guide/_preview_branch/XI-EORI](http://org-id.guide/_preview_branch/XI-EORI)  (visiting [http://org-id.guide/list/XI-EORI](http://org-id.guide/list/XI-EORI) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.