### PR TITLE
Northern Ireland Charity Register

### DIFF
--- a/lists/gb/gb-nic.json
+++ b/lists/gb/gb-nic.json
@@ -3,11 +3,7 @@
         "wikipedia": "https://en.wikipedia.org/wiki/Charity_Commission_for_Northern_Ireland",
         "opencorporates": null
     },
-    "sector": [
-        "education",
-        "humantiarian_relief",
-        "research"
-    ],
+    "sector": null,
     "url": "http://www.charitycommissionni.org.uk/charity-search/",
     "name": {
         "en": "The Charity Commission for Northern Ireland",


### PR DESCRIPTION
I've added some more information to update the entry for `GB-NIC`.

Strictly speaking, the `name` is the name of register maintaining body (Charity Commission NI) rather than the name of list itself, but 

So, I've left it but it might be better to swap the `en` and `local` values to:

    "name": {
        "en": "Northern Ireland Register of Charities",
        "local": "The Charity Commission for Northern Ireland"
    }