### PR TITLE
IT-CF: Italy Codice Fiscale (Tax number)

### DIFF
--- a/lists/it/it-cf.json
+++ b/lists/it/it-cf.json
@@ -27,7 +27,8 @@
     "guidanceOnLocatingIds": "The identifier to use along with the IT-CF code is reported as the 'Codice Fiscale' ('CF') and often as the 'Partitia IVA' ('P.IVA'). Some organisations will publish this number on their websites. ",
     "exampleIdentifiers": "80078410588, 91016940925",
     "languages": [
-      "it, en"
+      "it",
+      "en"
     ]
   },
   "data": {
@@ -47,5 +48,5 @@
     "opencorporates": "",
     "wikipedia": "https://it.wikipedia.org/wiki/Codice_fiscale"
   },
-  "formerPrefixes": []
+  "formerPrefixes": ["IT-RI"]
 }

--- a/lists/it/it-cf.json
+++ b/lists/it/it-cf.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Tax Code / VAT Number",
+    "local": "Codice Fiscale (CF) / Partitia IVA (P.IVA)"
+  },
+  "url": "http://www.registroimprese.it/",
+  "description": {
+    "en": "Companies (and some other entities) in Italy must register with the Business Register of the Chambers of Commerce. \n\nThey are assigned a Codice Fiscale (CF) or Tax Code which also acts as their Partitia IVA (P.IVA) or VAT Number. \n\nEntities may also be assigned an Economic and Administrative Directory (REA) identifier."
+  },
+  "coverage": [
+    "IT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity",
+    "company"
+  ],
+  "sector": [],
+  "code": "IT-CF",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "An online search allows the existence of a company to be confirmed. To access identifiers requires registration, and the payment of a small fee to conduct a search that will return identifiers. \n\nThe Italian Agency for Development Cooperation (Agenzia Italiana per la Cooperazione allo Sviluppo or 'AICS') maintain a list of civil society organisations ('Elenco CSO') registered with them. This includes those organsiations' names and CF/P.IVA as well as other information (address, website) which can be found here http://www.aics.gov.it/?page_id=7286. ",
+    "publicDatabase": "http://www.registroimprese.it/",
+    "guidanceOnLocatingIds": "The identifier to use along with the IT-CF code is reported as the 'Codice Fiscale' ('CF') and often as the 'Partitia IVA' ('P.IVA'). Some organisations will publish this number on their websites. ",
+    "exampleIdentifiers": "80078410588, 91016940925",
+    "languages": [
+      "it, en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "closed_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2017-09-15"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": "https://it.wikipedia.org/wiki/Codice_fiscale"
+  },
+  "formerPrefixes": []
+}

--- a/lists/it/it-ri.json
+++ b/lists/it/it-ri.json
@@ -18,7 +18,7 @@
   "sector": [],
   "code": "IT-RI",
   "confirmed": true,
-  "deprecated": false,
+  "deprecated": true,
   "listType": "primary",
   "access": {
     "availableOnline": true,
@@ -41,7 +41,7 @@
   },
   "meta": {
     "source": "Desk research",
-    "lastUpdated": "2017-09-04"
+    "lastUpdated": "2017-09-15"
   },
   "links": {
     "opencorporates": "",

--- a/lists/it/it-ri.json
+++ b/lists/it/it-ri.json
@@ -5,7 +5,7 @@
   },
   "url": "http://www.registroimprese.it/",
   "description": {
-    "en": "Companies (and some other entities) in Italy must register with the Business Register of the Chambers of Commerce. \n\nThey are assigned a Codice Fiscale (CF) or Tax Code. \n\nEntities may also be assigned an Economic and Administrative Directory (REA) identifier. "
+    "en": "Companies (and some other entities) in Italy must register with the Business Register of the Chambers of Commerce. \n\nThey are assigned a Codice Fiscale (CF) or Tax Code. \n\nEntities may also be assigned an Economic and Administrative Directory (REA) identifier. \n\n*Please note that this list has been deprecated in favour of IT-CF*"
   },
   "coverage": [
     "IT"
@@ -27,7 +27,8 @@
     "guidanceOnLocatingIds": "The identifier to use along with the IT-RI code is reported as the 'Codice Fiscale' or 'CF'.  Some organisations will publish this number on their websites. ",
     "exampleIdentifiers": "80078410588",
     "languages": [
-      "it, en"
+      "it",
+      "en"
     ]
   },
   "data": {

--- a/lists/it/it-ri.json
+++ b/lists/it/it-ri.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Business Register of the Italian Chambers of Commerce",
+    "local": "Registro Imprese delle Camere di Commercio (Italia)"
+  },
+  "url": "http://www.registroimprese.it/",
+  "description": {
+    "en": "Companies (and some other entities) in Italy must register with the Business Register of the Chambers of Commerce. \n\nThey are assigned a Codice Fiscale (CF) or Tax Code. \n\nEntities may also be assigned an Economic and Administrative Directory (REA) identifier. "
+  },
+  "coverage": [
+    "IT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity",
+    "company"
+  ],
+  "sector": [],
+  "code": "RI-IT",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "An online search allows the existence of a company to be confirmed. To access identifiers requires registration, and the payment of a small fee to conduct a search that will return identifiers.",
+    "publicDatabase": "http://www.registroimprese.it/",
+    "guidanceOnLocatingIds": "The identifier to use along with the IT-RI code is reported as the 'Codice Fiscale' or 'CF'.  Some organisations will publish this number on their websites. ",
+    "exampleIdentifiers": "80078410588",
+    "languages": [
+      "it, en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "closed_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2017-09-04"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/it/it-ri.json
+++ b/lists/it/it-ri.json
@@ -16,7 +16,7 @@
     "company"
   ],
   "sector": [],
-  "code": "RI-IT",
+  "code": "IT-RI",
   "confirmed": true,
   "deprecated": false,
   "listType": "primary",


### PR DESCRIPTION
Looking for a registration number/identifier to use for INGO based in Italy, we found the AICS register of civil society organisations, which can be identified by their Codice Fiscale (Tax number, also their VAT Number).

This describes where the CF can be found, deprecating the IT-RI list as this also describes the 'Registro Imprese': both lists use the CF as the identifier.

(Internal ticket #11117)