### PR TITLE
New list for Italy - Codice Fiscale IT-CF

### DIFF
--- a/lists/it/it-cf.json
+++ b/lists/it/it-cf.json
@@ -1,6 +1,6 @@
 {
   "name": {
-    "en": "Tax Code / VAT Number",
+    "en": "Italian Tax Code / VAT Number",
     "local": "Codice Fiscale (CF) / Partitia IVA (P.IVA)"
   },
   "url": "http://www.registroimprese.it/",
@@ -24,7 +24,7 @@
     "availableOnline": true,
     "onlineAccessDetails": "An online search allows the existence of a company to be confirmed. To access identifiers requires registration, and the payment of a small fee to conduct a search that will return identifiers. \n\nThe Italian Agency for Development Cooperation (Agenzia Italiana per la Cooperazione allo Sviluppo or 'AICS') maintain a list of civil society organisations ('Elenco CSO') registered with them. This includes those organsiations' names and CF/P.IVA as well as other information (address, website) which can be found here http://www.aics.gov.it/?page_id=7286. ",
     "publicDatabase": "http://www.registroimprese.it/",
-    "guidanceOnLocatingIds": "The identifier to use along with the IT-CF code is reported as the 'Codice Fiscale' ('CF') and often as the 'Partitia IVA' ('P.IVA'). Some organisations will publish this number on their websites. ",
+    "guidanceOnLocatingIds": "The identifier to use along with the IT-CF code is reported as the 'Codice Fiscale' ('CF') and often as the 'Partitia IVA' ('P.IVA'). Some organisations will publish this number on their websites. Check the Business Register or, for NGOs, the AICS register http://www.aics.gov.it/?page_id=7286",
     "exampleIdentifiers": "80078410588, 91016940925",
     "languages": [
       "it",


### PR DESCRIPTION
A new list has been proposed with the code IT-CF

**List title**: Codice Fiscale (Italy)

Preview the platform with this list at http://org-id.guide/_preview_branch/IT-CF (visiting http://org-id.guide/list/IT-CF when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.