### PR TITLE
Updated  registry entry for 'Local Authorities for England Register' (GB-LAE)

### DIFF
--- a/lists/gb/gb-lae.json
+++ b/lists/gb/gb-lae.json
@@ -3,9 +3,9 @@
     "en": "Local Authorities for England Register",
     "local": ""
   },
-  "url": "https://local-authority-eng.register.gov.uk/records",
+  "url": "https://local-authority-eng.register.gov.uk/records?page-index=1&page-size=5000",
   "description": {
-    "en": "The Local Authorities for England Register has been developed with the UK Department for Communities and Local Government (DCLG), and contains identifiers for 350+ local authorities. It also includes the 'local authority type' (e.g. Unitary Authority, London Borough) for each.\n\nIt uses the second portion of '[ISO_3166-2](https://en.wikipedia.org/wiki/ISO_3166-2:GB)' codes where these are available, and creates new codes where they are not. "
+    "en": "The Local Authorities for England Register has been developed with the UK Department for Communities and Local Government (DCLG), and contains identifiers for 350+ local authorities. It also includes the 'local authority type' (e.g. Unitary Authority, London Borough) for each.\n\nIt uses the second portion of [ISO_3166-2](https://en.wikipedia.org/wiki/ISO_3166-2:GB) codes where these are available, and creates new codes where they are not. For more information on GOV.UK Registers, visit https://registers.cloudapps.digital/"
   },
   "coverage": [
     "GB"
@@ -40,9 +40,10 @@
       "json",
       "rdf"
     ],
-    "dataAccessDetails": "",
+    "dataAccessDetails": "The list is available in CSV, TSV, JSON, YAML and TTL formats. There is also an open API, for guidance on how to use this visit https://registers-docs.cloudapps.digital/#api-documentation-for-registers",
     "features": [
       "date_of_registration",
+      "registration_number",
       "expiry_date",
       "status"
     ],
@@ -55,7 +56,7 @@
   },
   "links": {
     "opencorporates": "",
-    "wikipedia": ""
+    "wikipedia": "https://en.wikipedia.org/wiki/List_of_local_governments_in_the_United_Kingdom"
   },
   "formerPrefixes": []
 }

--- a/lists/gb/gb-lae.json
+++ b/lists/gb/gb-lae.json
@@ -5,7 +5,7 @@
   },
   "url": "https://local-authority-eng.register.gov.uk/records",
   "description": {
-    "en": "The Local Authorities for England Register has been developed with the UK Department for Communities and Local Government (DCLG), and contains identifiers for 350+ local authorities. \n\nIt uses the second portion of '[ISO_3166-2](https://en.wikipedia.org/wiki/ISO_3166-2:GB)' codes where these are available, and creates new codes where they are not. "
+    "en": "The Local Authorities for England Register has been developed with the UK Department for Communities and Local Government (DCLG), and contains identifiers for 350+ local authorities. It also includes the 'local authority type' (e.g. Unitary Authority, London Borough) for each.\n\nIt uses the second portion of '[ISO_3166-2](https://en.wikipedia.org/wiki/ISO_3166-2:GB)' codes where these are available, and creates new codes where they are not. "
   },
   "coverage": [
     "GB"
@@ -50,8 +50,8 @@
     "licenseDetails": "Open Government Licence v3.0"
   },
   "meta": {
-    "source": "https://github.com/OpenDataServices/org-ids/issues/67",
-    "lastUpdated": "2017-04-06"
+    "source": "https://github.com/OpenDataServices/org-ids/issues/64",
+    "lastUpdated": "2017-10-03"
   },
   "links": {
     "opencorporates": "",


### PR DESCRIPTION
An update to the list with code GB-LAE has been proposed

**List title:** Local Authorities for England Register

 Preview the platform with this list at [http://org-id.guide/_preview_branch/GB-LAE](http://org-id.guide/_preview_branch/GB-LAE)  (visiting [http://org-id.guide/list/GB-LAE](http://org-id.guide/list/GB-LAE) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.