### PR TITLE
[Proposed] ET-CSA Charities and Societies Agency (Ethiopia) #76

### DIFF
--- a/lists/et/et-csa.json
+++ b/lists/et/et-csa.json
@@ -1,0 +1,47 @@
+{
+  "name": {
+    "en": "Charities and Societies Agency (Ethiopia)",
+    "local": "የበጎ አድራጎት ድርጅቶችና ማህበራት ኤጀንሲ"
+  },
+  "url": "http://www.chsa.gov.et/",
+  "description": {
+    "en": "Most Charities and Societies which operate in Ethiopia are required to register with the Charities and Societies Agency, an institution of the Federal Government, which issues certificates of legal personality to those registered."
+  },
+  "coverage": [
+    "ET"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity"
+  ],
+  "sector": [],
+  "code": "ET-CSA",
+  "confirmed": true,
+  "deprecated": false,
+  "access": {
+    "onlineAccessDetails": "",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": [
+      "EN"
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "original research",
+    "lastUpdated": "2017-10-17T10:00:00Z"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/et/et-csa.json
+++ b/lists/et/et-csa.json
@@ -18,6 +18,7 @@
   "code": "ET-CSA",
   "confirmed": true,
   "deprecated": false,
+  "listType": "primary",
   "access": {
     "onlineAccessDetails": "",
     "publicDatabase": "",


### PR DESCRIPTION
A new list has been proposed with the code ET-CSA after a request from an IATI publisher (#76) 

**List title**:  Charities and Societies Agency (Ethiopia)

Preview the org-id.guide platform with this list at http://org-id.guide/_preview_branch/ET-CSA (visiting http://org-id.guide/list/ET-CSA when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.

_Please note that the registration list is not accessible online._