### PR TITLE
Updated  registry entry for 'Ministry of Foreign affairs' (ID-KLN)

### DIFF
--- a/lists/id/id-kln.json
+++ b/lists/id/id-kln.json
@@ -1,49 +1,49 @@
 {
-    "links": {
-        "wikipedia": null,
-        "opencorporates": null
-    },
-    "sector": null,
-    "url": "http://www.kemlu.go.id/",
-    "name": {
-        "en": "Ministry of Foreign affairs",
-        "local": " Kementerian Luar Negeri"
-    },
-    "coverage": [
-        "ID"
+  "name": {
+    "en": "Ministry of Foreign affairs",
+    "local": " Kementerian Luar Negeri"
+  },
+  "url": "http://www.kemlu.go.id/",
+  "description": {
+    "en": "All NGOs foreign to Indonesia who wish to operate in the country must register through the Ministry of Foreign affairs/ Kementerian Luar Negeri. \n\n\"Registration Process:\n\n1.    INGO submit complete application documents to the Government of the Republic of Indonesia through the Ministry of Foreign Affairs\" [1]\n\n[1] http://www.kemlu.go.id/en/berita/informasi-penting/Pages/Registration-Guidelines-for-International-Non-Governmental-Organizations-in-Indonesia.aspx"
+  },
+  "coverage": [
+    "ID"
+  ],
+  "subnationalCoverage": [],
+  "structure": [],
+  "sector": [],
+  "code": "ID-KLN",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": null,
+    "publicDatabase": "http://www.smeru.or.id/en/content/ngo-database",
+    "guidanceOnLocatingIds": "No source of identifiers was found during research. ",
+    "exampleIdentifiers": "",
+    "languages": [
+      "en",
+      "id"
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
     ],
-    "code": "ID-KLN",
-    "formerPrefixes": null,
-    "confirmed": true,
-    "data": {
-        "features": null,
-        "dataAccessDetails": null,
-        "licenseDetails": null,
-        "licenseStatus": "no_license",
-        "availability": [
-            "data_not_available"
-        ]
-    },
-    "deprecated": null,
-    "structure": null,
-    "description": {
-        "en": "All NGOs foreign to Indonesia who wish to operate in the country must register through the Ministry of Foreign affairs/ Kementerian Luar Negeri. \n\n\"Registration Process:\n\n1.    INGO submit complete application documents to the Government of the Republic of Indonesia through the Ministry of Foreign Affairs\" [1]\n\n[1] http://www.kemlu.go.id/en/berita/informasi-penting/Pages/Registration-Guidelines-for-International-Non-Governmental-Organizations-in-Indonesia.aspx"
-    },
-    "meta": {
-        "lastUpdated": "2016-11-29",
-        "source": null
-    },
-    "access": {
-        "languages": [
-            "en",
-            "id"
-        ],
-        "exampleIdentifiers": null,
-        "onlineAccessDetails": null,
-        "publicDatabase": "http://www.smeru.or.id/en/content/ngo-database",
-        "availableOnline": false,
-        "guidanceOnLocatingIds": "No identifiers found.\n\nOIPA search returns zero results"
-    },
-    "subnationalCoverage": null,
-    "listType": "secondary"
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "",
+    "lastUpdated": "2017-10-25"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
 }


### PR DESCRIPTION
An update to the list with code ID-KLN has been proposed

**List title:** Ministry of Foreign affairs

Removing artefacts from the research process (reference to OIPA. See #80)

 Preview the platform with this list at [http://org-id.guide/_preview_branch/ID-KLN](http://org-id.guide/_preview_branch/ID-KLN)  (visiting [http://org-id.guide/list/ID-KLN](http://org-id.guide/list/ID-KLN) when the preview is active or check the files changed options above.

This is considered a minor change, and so will be merged shortly, but may be reverted if objections are raised in the next 7 days.