### PR TITLE
New  registry entry for 'National Identification Number of Companies and Associations (Senegal)' (SN-NINEA)

### DIFF
--- a/lists/sn/sn-ninea.json
+++ b/lists/sn/sn-ninea.json
@@ -1,0 +1,52 @@
+{
+  "name": {
+    "en": "National Identification Number of Companies and Associations (Senegal)",
+    "local": "Numéro d'identification nationale des entreprises et des associations - NINEA (Senegal)"
+  },
+  "url": "",
+  "description": {
+    "en": "Any organization (company, association, NGO) operating in Senegal must be included in a directory of legal entities ([Source](http://www.impotsetdomaines.gouv.sn/fr/demander-un-ninea)). \n\nRegistration takes place through several agencies, and a Numéro d’Identification National des Entreprises et des Associations (NINEA) (National Identification Number for Companies and Associations) is provided to incorporated bodies.\n\nA directory or lookup of companies and numbers is not available online, however most legal entities will have an NINEA which can be used as an identifier."
+  },
+  "coverage": [
+    "SN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity",
+    "company",
+    "trust"
+  ],
+  "sector": [],
+  "code": "SN-NINEA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "A list is not available online. However, a NINEA number can be used in conjunction with the list code prefix to produce a unique identifier.",
+    "exampleIdentifiers": "621108990A0",
+    "languages": [
+      "FR"
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Research by Open Data Services.",
+    "lastUpdated": "2017-10-25T16:22:00Z"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sn/sn-ninea.json
+++ b/lists/sn/sn-ninea.json
@@ -1,9 +1,9 @@
 {
   "name": {
-    "en": "National Identification Number of Companies and Associations (Senegal)",
-    "local": "Numéro d'identification nationale des entreprises et des associations - NINEA (Senegal)"
+    "en": "National Identification Number of Companies and Associations (NINEA), Senegal",
+    "local": "Numéro d'Identification Nationale des Entreprises et des Associations - NINEA (Senegal)"
   },
-  "url": "",
+  "url": "http://creationdentreprise.sn/en/finding-business",
   "description": {
     "en": "Any organization (company, association, NGO) operating in Senegal must be included in a directory of legal entities ([Source](http://www.impotsetdomaines.gouv.sn/fr/demander-un-ninea)). \n\nRegistration takes place through several agencies, and a Numéro d’Identification National des Entreprises et des Associations (NINEA) (National Identification Number for Companies and Associations) is provided to incorporated bodies.\n\nA directory or lookup of companies and numbers is not available online, however most legal entities will have an NINEA which can be used as an identifier."
   },
@@ -22,12 +22,13 @@
   "deprecated": false,
   "listType": "primary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "",
-    "publicDatabase": "",
-    "guidanceOnLocatingIds": "A list is not available online. However, a NINEA number can be used in conjunction with the list code prefix to produce a unique identifier.",
-    "exampleIdentifiers": "621108990A0",
+    "availableOnline": true,
+    "onlineAccessDetails": "A (possible partial) and freely accessible online list is available from the Senegalese Bureau d'appui à la Création d'Entreprise (BCE) http://creationdentreprise.sn/en/finding-business.",
+    "publicDatabase": "http://creationdentreprise.sn/en/finding-business",
+    "guidanceOnLocatingIds": "A NINÉA number can be used in conjunction with the list code prefix to produce a unique identifier.",
+    "exampleIdentifiers": "006478110, 006470108, 006480256",
     "languages": [
+      "EN",
       "FR"
     ]
   },
@@ -42,7 +43,7 @@
   },
   "meta": {
     "source": "Research by Open Data Services.",
-    "lastUpdated": "2017-10-25T16:22:00Z"
+    "lastUpdated": "2017-11-05T17:30:00Z"
   },
   "links": {
     "opencorporates": "",


### PR DESCRIPTION
A new list has been proposed with the code SN-NINEA

**List title:** National Identification Number of Companies and Associations (Senegal)

Adding SN-NINEA list (Senegal)

 Preview the platform with this list at [http://org-id.guide/_preview_branch/SN-NINEA](http://org-id.guide/_preview_branch/SN-NINEA)  (visiting [http://org-id.guide/list/SN-NINEA](http://org-id.guide/list/SN-NINEA) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.