### PR TITLE
Updated  registry entry for 'Register of Enterprises of the Republic of Latvia' (LV-RE)

### DIFF
--- a/lists/lv/lv-re.json
+++ b/lists/lv/lv-re.json
@@ -1,7 +1,7 @@
 {
   "name": {
     "en": "Register of Enterprises of the Republic of Latvia",
-    "local": ""
+    "local": "Latvijas Republikas Uzņēmumu Reģistrs"
   },
   "url": "http://www.ur.gov.lv/",
   "description": {
@@ -20,11 +20,11 @@
   "deprecated": false,
   "listType": "primary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "Data is available through simple, searchable function on government webpage, on an alternative website (Lursoft) and also as CSV download",
-    "publicDatabase": "http://www.ur.gov.lv/, http://www.lursoft.lv/?v=en, http://dati.ur.gov.lv/register/",
-    "guidanceOnLocatingIds": "Users can find identifiers by using the search bar which is present near the top of every page on the website [1]. Users must have a name or key word, and select 'Company / Organisation' on the drop-down box to the right of the search bar.\n\nThe identifier will be next to the heading 'Registration number' in the results shown.\n\nUsers can also download a CSV of the entire registry[2].\n\nUsers can also use the search on the Lursoft website[3]. After opening one of the results, the identifier can be found next to the heading 'Registration number'.\n\n[1] http://www.ur.gov.lv/\n[2] http://dati.ur.gov.lv/register/\n[3] http://www.lursoft.lv/?v=en",
-    "exampleIdentifiers": "40008124830, 51203041201, 40008124830",
+    "availableOnline": true,
+    "onlineAccessDetails": "Data is available through simple, searchable function on government webpage, on an alternative website (Lursoft) and also CSV and Excel open data downloads",
+    "publicDatabase": "http://www.ur.gov.lv/",
+    "guidanceOnLocatingIds": "# Users can find identifiers by using the search bar which is present near the top of every page on the website [1]. Users must have a name or key word, and select 'Company / Organisation' on the drop-down box to the right of the search bar. The identifier will be next to the heading 'Registration number' ('Reģistrācijas numurs') in the results shown.\n\n# Users can also download a CSV of the entire registry[2], where the identifier appears under the 'regcode'\n\n# Users can also use the search on the Lursoft website in English[3]. After opening one of the results, the identifier can be found under the heading 'VAT number' and should have the LV prefix removed before use as an org-id format identifier.\n\n[1] http://www.ur.gov.lv/\n[2] http://dati.ur.gov.lv/register/\n[3] http://www.lursoft.lv/?v=en",
+    "exampleIdentifiers": "40008124830, 51203041201, 40003108882",
     "languages": [
       "en",
       "lv"
@@ -32,20 +32,25 @@
   },
   "data": {
     "availability": [
-      "csv"
+      "bulk",
+      "csv",
+      "excel"
     ],
-    "dataAccessDetails": "Link to CSV download found at http://index.okfn.org/place/latvia/companies/   , Link to Lursoft found at https://opencorporates.com/registers/137 . More detailed information in Lursoft, and Lursoft is in English, whereas ur.gov.lv is in Latvian",
+    "dataAccessDetails": "The full company registry dataset can be found at http://dati.ur.gov.lv/ in the register/register.csv and register/register.xlsx files and also at https://data.gov.lv/dati/lv/dataset/uz.",
     "features": [
       "registered_address",
       "date_of_registration",
-      "registration_number"
+      "registration_number",
+      "activities_sector_code",
+      "expiry_date",
+      "status"
     ],
     "licenseStatus": "open_license",
-    "licenseDetails": "https://opencorporates.com/registers/137, http://index.okfn.org/place/latvia/companies/"
+    "licenseDetails": "Creative Commons Zero (CC0 1.0) https://data.gov.lv/dati/lv/dataset/uz"
   },
   "meta": {
     "source": "Desk research",
-    "lastUpdated": "2017-11-08"
+    "lastUpdated": "2017-11-17"
   },
   "links": {
     "opencorporates": "http://opencorporates.com/companies/lv",

--- a/lists/lv/lv-re.json
+++ b/lists/lv/lv-re.json
@@ -22,8 +22,8 @@
   "access": {
     "availableOnline": false,
     "onlineAccessDetails": "Data is available through simple, searchable function on government webpage, on an alternative website (Lursoft) and also as CSV download",
-    "publicDatabase": "http://www.ur.gov.lv/ , http://www.lursoft.lv/?v=en, http://dati.ur.gov.lv/register/",
-    "guidanceOnLocatingIds": "Users can find identifiers by using the search bar which is present near the top of every page on the website. Users must have a name or key word, and select 'Company / Organisation' on the drop-down box to the right of the search bar.\n\nThe identifier will be next to the heading 'Registration number' in the results shown.\n\nUsers can also download a CSV of the entire registry.\n\nUsers can also use the search on the Lursoft website. After opening one of the results, the identifier can be found next to the heading 'Registration number'.",
+    "publicDatabase": "http://www.ur.gov.lv/, http://www.lursoft.lv/?v=en, http://dati.ur.gov.lv/register/",
+    "guidanceOnLocatingIds": "Users can find identifiers by using the search bar which is present near the top of every page on the website [1]. Users must have a name or key word, and select 'Company / Organisation' on the drop-down box to the right of the search bar.\n\nThe identifier will be next to the heading 'Registration number' in the results shown.\n\nUsers can also download a CSV of the entire registry[2].\n\nUsers can also use the search on the Lursoft website[3]. After opening one of the results, the identifier can be found next to the heading 'Registration number'.\n\n[1] http://www.ur.gov.lv/\n[2] http://dati.ur.gov.lv/register/\n[3] http://www.lursoft.lv/?v=en",
     "exampleIdentifiers": "40008124830, 51203041201, 40008124830",
     "languages": [
       "en",
@@ -41,11 +41,11 @@
       "registration_number"
     ],
     "licenseStatus": "open_license",
-    "licenseDetails": "https://opencorporates.com/registers/137 , http://index.okfn.org/place/latvia/companies/"
+    "licenseDetails": "https://opencorporates.com/registers/137, http://index.okfn.org/place/latvia/companies/"
   },
   "meta": {
     "source": "Desk research",
-    "lastUpdated": "2016-11-26"
+    "lastUpdated": "2017-11-08"
   },
   "links": {
     "opencorporates": "http://opencorporates.com/companies/lv",

--- a/lists/lv/lv-re.json
+++ b/lists/lv/lv-re.json
@@ -1,58 +1,55 @@
 {
-    "links": {
-        "wikipedia": null,
-        "opencorporates": "http://opencorporates.com/companies/lv"
-    },
-    "sector": null,
-    "url": "http://www.ur.gov.lv/",
-    "name": {
-        "en": "Register of Enterprises of the Republic of Latvia",
-        "local": ""
-    },
-    "coverage": [
-        "LV"
+  "name": {
+    "en": "Register of Enterprises of the Republic of Latvia",
+    "local": ""
+  },
+  "url": "http://www.ur.gov.lv/",
+  "description": {
+    "en": "The Register of Enterprises registers companies and maintains a database of organisation information. This information is searchable on the website and can be found in CSV form.\n\n\"Register of Enterprises is the central institution which keeps all data and records up to date. It is mandatory to submit incorporation documents with the registry at the moment of company establishment, as well as to file all amendments in the company board (directors) or shareholder registry.\n\nThe unified register is also available electronically.\n\nThe Register of Enterprises has the following functions:\nto register undertakings and their branches, representative offices and representatives of foreign undertakings and organisations, co-operative companies,\" [1]\n\n[1] http://www.baltic-legal.com/commercial-register-of-latvia-eng.htm\n\nFree of charge information includes type of legal entity; registered office; new or current name or trade name and previously registered or historical name or trade name; registration number; Single Euro Payment Area beneficiary identification code (if allocated); registration date; date of deletion of the legal entity from the register (or the date of reorganisation if the reason for the deletion is a reorganisation); deadline for registration of religious organisations that are subject to re-registration."
+  },
+  "coverage": [
+    "LV"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "company"
+  ],
+  "sector": [],
+  "code": "LV-RE",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Data is available through simple, searchable function on government webpage, on an alternative website (Lursoft) and also as CSV download",
+    "publicDatabase": "http://www.ur.gov.lv/ , http://www.lursoft.lv/?v=en, http://dati.ur.gov.lv/register/",
+    "guidanceOnLocatingIds": "Users can find identifiers by using the search bar which is present near the top of every page on the website. Users must have a name or key word, and select 'Company / Organisation' on the drop-down box to the right of the search bar.\n\nThe identifier will be next to the heading 'Registration number' in the results shown.\n\nUsers can also download a CSV of the entire registry.\n\nUsers can also use the search on the Lursoft website. After opening one of the results, the identifier can be found next to the heading 'Registration number'.",
+    "exampleIdentifiers": "40008124830, 51203041201, 40008124830",
+    "languages": [
+      "en",
+      "lv"
+    ]
+  },
+  "data": {
+    "availability": [
+      "csv"
     ],
-    "code": "LV-RE",
-    "formerPrefixes": null,
-    "confirmed": true,
-    "data": {
-        "features": [
-            "registered_address",
-            "organisation_name",
-            "date_of_registration",
-            "registration_number",
-            "organisation_type"
-        ],
-        "dataAccessDetails": "Link to CSV download found at http://index.okfn.org/place/latvia/companies/   , Link to Lursoft found at https://opencorporates.com/registers/137 . More detailed information in Lursoft, and Lursoft is in English, whereas ur.gov.lv is in Latvian",
-        "licenseDetails": "https://opencorporates.com/registers/137 , http://index.okfn.org/place/latvia/companies/",
-        "licenseStatus": "open_license",
-        "availability": [
-            "csv",
-            "html"
-        ]
-    },
-    "deprecated": null,
-    "structure": [
-        "company"
+    "dataAccessDetails": "Link to CSV download found at http://index.okfn.org/place/latvia/companies/   , Link to Lursoft found at https://opencorporates.com/registers/137 . More detailed information in Lursoft, and Lursoft is in English, whereas ur.gov.lv is in Latvian",
+    "features": [
+      "registered_address",
+      "date_of_registration",
+      "registration_number"
     ],
-    "description": {
-        "en": "The Register of Enterprises registers companies and maintains a database of organisation information. This information is searchable on the website and can be found in CSV form.\n\n\"Register of Enterprises is the central institution which keeps all data and records up to date. It is mandatory to submit incorporation documents with the registry at the moment of company establishment, as well as to file all amendments in the company board (directors) or shareholder registry.\n\nThe unified register is also available electronically.\n\nThe Register of Enterprises has the following functions:\nto register undertakings and their branches, representative offices and representatives of foreign undertakings and organisations, co-operative companies,\" [1]\n\n[1] http://www.baltic-legal.com/commercial-register-of-latvia-eng.htm\n\nFree of charge information includes type of legal entity; registered office; new or current name or trade name and previously registered or historical name or trade name; registration number; Single Euro Payment Area beneficiary identification code (if allocated); registration date; date of deletion of the legal entity from the register (or the date of reorganisation if the reason for the deletion is a reorganisation); deadline for registration of religious organisations that are subject to re-registration."
-    },
-    "meta": {
-        "lastUpdated": "2016-11-26",
-        "source": "Desk research"
-    },
-    "access": {
-        "languages": [
-            "en",
-            "lv"
-        ],
-        "exampleIdentifiers": "40008124830, 51203041201, 40008124830",
-        "onlineAccessDetails": "Data is available through simple, searchable function on government webpage, on an alternative website (Lursoft) and also as CSV download",
-        "publicDatabase": "http://www.ur.gov.lv/ , http://www.lursoft.lv/?v=en, http://dati.ur.gov.lv/register/",
-        "availableOnline": false,
-        "guidanceOnLocatingIds": "Users can find identifiers by using the search bar which is present near the top of every page on the website. Users must have a name or key word, and select 'Company / Organisation' on the drop-down box to the right of the search bar.\n\nThe identifier will be next to the heading 'Registration number' in the results shown.\n\nUsers can also download a CSV of the entire registry.\n\nUsers can also use the search on the Lursoft website. After opening one of the results, the identifier can be found next to the heading 'Registration number'."
-    },
-    "subnationalCoverage": null,
-    "listType": "primary"
+    "licenseStatus": "open_license",
+    "licenseDetails": "https://opencorporates.com/registers/137 , http://index.okfn.org/place/latvia/companies/"
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2016-11-26"
+  },
+  "links": {
+    "opencorporates": "http://opencorporates.com/companies/lv",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
 }


### PR DESCRIPTION
An update to the list with code LV-RE has been proposed

**List title:** Register of Enterprises of the Republic of Latvia

Reviewed

 Preview the platform with this list at [http://org-id.guide/_preview_branch/LV-RE](http://org-id.guide/_preview_branch/LV-RE)  (visiting [http://org-id.guide/list/LV-RE](http://org-id.guide/list/LV-RE) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.