### PR TITLE
New  registry entry for 'Cyprus Department of Registrar of Companies and Official Receiver (DRCOR)' (CY-DRCOR)

### DIFF
--- a/lists/cy/cy-drcor.json
+++ b/lists/cy/cy-drcor.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": true,
+        "exampleIdentifiers": "12032",
+        "guidanceOnLocatingIds": "Company registration number can be found under `Reg. Number` header",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "Company can be searched by its name or registration number. Search results show the company's name, registration number, type, name status, and organisation status. There is English, Greek, and Turkish interface.",
+        "publicDatabase": ""
+    },
+    "code": "CY-DRCOR",
+    "confirmed": true,
+    "coverage": [
+        "CY"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "Department of Registrar of Companies and Official Receiver maintains the register of companies, partnerships, business names, and overseas companies."
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "primary",
+    "meta": {
+        "lastUpdated": "2017-10-24",
+        "source": "ProZorro Business Register Research"
+    },
+    "name": {
+        "en": "Cyprus Department of Registrar of Companies and Official Receiver (DRCOR)\n",
+        "local": "\u015eirketler Mukayyidi ve Resmi Sendik Dairesi"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "https://efiling.drcor.mcit.gov.cy/DrcorPublic/Default.aspx?cultureInfo=en-AU"
+}

--- a/lists/cy/cy-drcor.json
+++ b/lists/cy/cy-drcor.json
@@ -1,48 +1,55 @@
 {
-    "access": {
-        "availableOnline": true,
-        "exampleIdentifiers": "12032",
-        "guidanceOnLocatingIds": "Company registration number can be found under `Reg. Number` header",
-        "languages": [
-            ""
-        ],
-        "onlineAccessDetails": "Company can be searched by its name or registration number. Search results show the company's name, registration number, type, name status, and organisation status. There is English, Greek, and Turkish interface.",
-        "publicDatabase": ""
-    },
-    "code": "CY-DRCOR",
-    "confirmed": true,
-    "coverage": [
-        "CY"
+  "name": {
+    "en": "Cyprus Department of Registrar of Companies and Official Receiver (DRCOR)",
+    "local": "Şirketler Mukayyidi ve Resmi Sendik Dairesi"
+  },
+  "url": "https://efiling.drcor.mcit.gov.cy/DrcorPublic/Default.aspx?cultureInfo=en-AU",
+  "description": {
+    "en": "Department of Registrar of Companies and Official Receiver maintains the register of companies, partnerships, business names, and overseas companies."
+  },
+  "coverage": [
+    "CY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "company"
+  ],
+  "sector": [],
+  "code": "CY-DRCOR",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Company can be searched by its name or registration number. Search results show the company's name, registration number, type, name status, and organisation status. There is English, Greek, and Turkish interface.",
+    "publicDatabase": "https://efiling.drcor.mcit.gov.cy/DrcorPublic/Default.aspx?cultureInfo=en-AU",
+    "guidanceOnLocatingIds": "Company registration number can be found under `Reg. Number` header",
+    "exampleIdentifiers": "12032",
+    "languages": [
+      "el",
+      "tr",
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
     ],
-    "data": {
-        "availability": [],
-        "dataAccessDetails": "",
-        "features": [],
-        "licenseDetails": "",
-        "licenseStatus": "open_license"
-    },
-    "deprecated": false,
-    "description": {
-        "en": "Department of Registrar of Companies and Official Receiver maintains the register of companies, partnerships, business names, and overseas companies."
-    },
-    "formerPrefixes": [],
-    "links": {
-        "opencorporates": "",
-        "wikipedia": ""
-    },
-    "listType": "primary",
-    "meta": {
-        "lastUpdated": "2017-10-24",
-        "source": "ProZorro Business Register Research"
-    },
-    "name": {
-        "en": "Cyprus Department of Registrar of Companies and Official Receiver (DRCOR)\n",
-        "local": "\u015eirketler Mukayyidi ve Resmi Sendik Dairesi"
-    },
-    "sector": [],
-    "structure": [
-        "company"
+    "dataAccessDetails": "",
+    "features": [
+      "directors_trustees_governors",
+      "registered_address"
     ],
-    "subnationalCoverage": [],
-    "url": "https://efiling.drcor.mcit.gov.cy/DrcorPublic/Default.aspx?cultureInfo=en-AU"
+    "licenseStatus": "open_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "ProZorro Business Register Research",
+    "lastUpdated": "2017-10-24"
+  },
+  "links": {
+    "opencorporates": "https://opencorporates.com/companies/cy",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
 }


### PR DESCRIPTION
A new list has been proposed with the code CY-DRCOR

**List title:** Cyprus Department of Registrar of Companies and Official Receiver (DRCOR)

Reviewed

 Preview the platform with this list at [http://org-id.guide/_preview_branch/CY-DRCOR](http://org-id.guide/_preview_branch/CY-DRCOR)  (visiting [http://org-id.guide/list/CY-DRCOR](http://org-id.guide/list/CY-DRCOR) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.