### PR TITLE
New  registry entry for 'State Register of Commercial Entities (Ministry of Taxes of Azerbaijan Republic)' (AZ-IVI)

### DIFF
--- a/lists/az/az-ivi.json
+++ b/lists/az/az-ivi.json
@@ -1,48 +1,49 @@
 {
-    "access": {
-        "availableOnline": true,
-        "exampleIdentifiers": "9900014901",
-        "guidanceOnLocatingIds": "TIN (aka company registration number) is under `V\u00d6EN` header",
-        "languages": [
-            ""
-        ],
-        "onlineAccessDetails": "Company can be searched by TIN or legal name. Information provided: name of commercial organization, TIN, taxpayer's name, organizational-legal form, legal address, charter capital, fiscal year, legal representative, registration date. No English interface.",
-        "publicDatabase": ""
-    },
-    "code": "AZ-IVI",
-    "confirmed": true,
-    "coverage": [
-        "AZ"
+  "name": {
+    "en": "State Register of Commercial Entities (Ministry of Taxes of Azerbaijan Republic)",
+    "local": "Kommersiya qurumlarının dövlət reyestri"
+  },
+  "url": "https://www.e-taxes.gov.az/ebyn/commersialChecker.jsp",
+  "description": {
+    "en": "Available only in Azerbaijani"
+  },
+  "coverage": [
+    "AZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "company"
+  ],
+  "sector": [],
+  "code": "AZ-IVI",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Company can be searched by VÖEN or legal name. \n\nName searches return a list of possible company name matches and their VÖEN codes.\n\nIf searching by the VOEN more information will be provided: name of commercial organization, taxpayer's name, organizational-legal form, legal address, charter capital, fiscal year, legal representative, registration date. \n\nNo English interface.",
+    "publicDatabase": "https://www.e-taxes.gov.az/ebyn/commersialChecker.jsp",
+    "guidanceOnLocatingIds": "10-digit TIN (aka company registration number) is under 'VÖEN' header",
+    "exampleIdentifiers": "990001490, 3100073821",
+    "languages": [
+      "az"
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
     ],
-    "data": {
-        "availability": [],
-        "dataAccessDetails": "",
-        "features": [],
-        "licenseDetails": "",
-        "licenseStatus": "open_license"
-    },
-    "deprecated": false,
-    "description": {
-        "en": "Available only in Azerbaijani"
-    },
-    "formerPrefixes": [],
-    "links": {
-        "opencorporates": "",
-        "wikipedia": ""
-    },
-    "listType": "primary",
-    "meta": {
-        "lastUpdated": "2017-10-24",
-        "source": "ProZorro Business Register Research"
-    },
-    "name": {
-        "en": "State Register of Commercial Entities (The Ministry of Taxes of Azerbaijan Republic) Internet Tax Administration",
-        "local": "Kommersiya qurumlar\u0131n\u0131n d\u00f6vl\u0259t reyestri. Internet vergi idar\u0259si"
-    },
-    "sector": [],
-    "structure": [
-        "company"
-    ],
-    "subnationalCoverage": [],
-    "url": "https://www.e-taxes.gov.az/ebyn/commersialChecker.jsp"
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "ProZorro Business Register Research",
+    "lastUpdated": "2017-11-08"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
 }

--- a/lists/az/az-ivi.json
+++ b/lists/az/az-ivi.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": true,
+        "exampleIdentifiers": "9900014901",
+        "guidanceOnLocatingIds": "TIN (aka company registration number) is under `V\u00d6EN` header",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "Company can be searched by TIN or legal name. Information provided: name of commercial organization, TIN, taxpayer's name, organizational-legal form, legal address, charter capital, fiscal year, legal representative, registration date. No English interface.",
+        "publicDatabase": ""
+    },
+    "code": "AZ-IVI",
+    "confirmed": true,
+    "coverage": [
+        "AZ"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "Available only in Azerbaijani"
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "primary",
+    "meta": {
+        "lastUpdated": "2017-10-24",
+        "source": "ProZorro Business Register Research"
+    },
+    "name": {
+        "en": "State Register of Commercial Entities (The Ministry of Taxes of Azerbaijan Republic) Internet Tax Administration",
+        "local": "Kommersiya qurumlar\u0131n\u0131n d\u00f6vl\u0259t reyestri. Internet vergi idar\u0259si"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "https://www.e-taxes.gov.az/ebyn/commersialChecker.jsp"
+}


### PR DESCRIPTION
A new list has been proposed with the code AZ-IVI

**List title:** State Register of Commercial Entities (Ministry of Taxes of Azerbaijan Republic)

reviewed

 Preview the platform with this list at [http://org-id.guide/_preview_branch/AZ-IVI](http://org-id.guide/_preview_branch/AZ-IVI)  (visiting [http://org-id.guide/list/AZ-IVI](http://org-id.guide/list/AZ-IVI) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.