### PR TITLE
New  registry entry for 'Slovenian Business Register' (SI-PRS)

### DIFF
--- a/lists/si/si-prs.json
+++ b/lists/si/si-prs.json
@@ -1,7 +1,7 @@
 {
   "name": {
     "en": "Slovenian Business Register",
-    "local": "Matična številka"
+    "local": "Poslovni register Slovenije"
   },
   "url": "http://www.ajpes.eu/prs/",
   "description": {
@@ -15,7 +15,7 @@
     "company"
   ],
   "sector": [],
-  "code": "SL-PRS",
+  "code": "SI-PRS",
   "confirmed": true,
   "deprecated": false,
   "listType": "primary",

--- a/lists/si/si-prs.json
+++ b/lists/si/si-prs.json
@@ -1,48 +1,47 @@
 {
-    "access": {
-        "availableOnline": true,
-        "exampleIdentifiers": "5092108",
-        "guidanceOnLocatingIds": "",
-        "languages": [
-            ""
-        ],
-        "onlineAccessDetails": "",
-        "publicDatabase": ""
-    },
-    "code": "SI-PRS",
-    "confirmed": true,
-    "coverage": [
-        "SI"
-    ],
-    "data": {
-        "availability": [],
-        "dataAccessDetails": "",
-        "features": [],
-        "licenseDetails": "",
-        "licenseStatus": "open_license"
-    },
-    "deprecated": false,
-    "description": {
-        "en": "The Slovenian Business Register (PRS) is a central database containing information about all business entities involved in a profit or non-profit activity having their principal place of business located on the territory of the Republic of Slovenia, as well as information on their subsidiaries and other divisions of business entities performing business activities in the territory of the Republic of Slovenia."
-    },
-    "formerPrefixes": [],
-    "links": {
-        "opencorporates": "",
-        "wikipedia": ""
-    },
-    "listType": "primary",
-    "meta": {
-        "lastUpdated": "2017-10-24",
-        "source": "ProZorro Business Register Research"
-    },
-    "name": {
-        "en": "Company Identification Number",
-        "local": "Mati\u010dna \u0161tevilka"
-    },
-    "sector": [],
-    "structure": [
-        "company"
-    ],
-    "subnationalCoverage": [],
-    "url": "http://www.ajpes.eu/prs/"
+  "name": {
+    "en": "Slovenian Business Register",
+    "local": "Matična številka"
+  },
+  "url": "http://www.ajpes.eu/prs/",
+  "description": {
+    "en": "The Slovenian Business Register (PRS) is a central database containing information about all business entities involved in a profit or non-profit activity having their principal place of business located on the territory of the Republic of Slovenia, as well as information on their subsidiaries and other divisions of business entities performing business activities in the territory of the Republic of Slovenia."
+  },
+  "coverage": [
+    "SI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "company"
+  ],
+  "sector": [],
+  "code": "SL-PRS",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "5092108",
+    "languages": [
+      "sl"
+    ]
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "ProZorro Business Register Research",
+    "lastUpdated": "2017-10-24"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
 }

--- a/lists/si/si-prs.json
+++ b/lists/si/si-prs.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": true,
+        "exampleIdentifiers": "5092108",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "",
+        "publicDatabase": ""
+    },
+    "code": "SI-PRS",
+    "confirmed": true,
+    "coverage": [
+        "SI"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "The Slovenian Business Register (PRS) is a central database containing information about all business entities involved in a profit or non-profit activity having their principal place of business located on the territory of the Republic of Slovenia, as well as information on their subsidiaries and other divisions of business entities performing business activities in the territory of the Republic of Slovenia."
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "primary",
+    "meta": {
+        "lastUpdated": "2017-10-24",
+        "source": "ProZorro Business Register Research"
+    },
+    "name": {
+        "en": "Company Identification Number",
+        "local": "Mati\u010dna \u0161tevilka"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "http://www.ajpes.eu/prs/"
+}


### PR DESCRIPTION
A new list has been proposed with the code SI-PRS

**List title:** Slovenian Business Register

Reviewed

 Preview the platform with this list at [http://org-id.guide/_preview_branch/SI-PRS](http://org-id.guide/_preview_branch/SI-PRS)  (visiting [http://org-id.guide/list/SI-PRS](http://org-id.guide/list/SI-PRS) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.