### PR TITLE
New  registry entry for 'National Tax Agency Corporate Number Publication Site' (JP-JCN)

### DIFF
--- a/lists/jp/jp-jcn.json
+++ b/lists/jp/jp-jcn.json
@@ -1,48 +1,49 @@
 {
-    "access": {
-        "availableOnline": true,
-        "exampleIdentifiers": "7010001008844",
-        "guidanceOnLocatingIds": "",
-        "languages": [
-            ""
-        ],
-        "onlineAccessDetails": "Company can be searched by legal name and corporate number. Search results provide corporate number, name, address, change history information. English interface available, search is free of charge. ",
-        "publicDatabase": ""
-    },
-    "code": "JP-JCN",
-    "confirmed": true,
-    "coverage": [
-        "JP"
-    ],
-    "data": {
-        "availability": [],
-        "dataAccessDetails": "",
-        "features": [],
-        "licenseDetails": "",
-        "licenseStatus": "open_license"
-    },
-    "deprecated": false,
-    "description": {
-        "en": "A code allocated to a company by the Japanese National Tax Agency. The registry itself is open and searchable by JCN (in Japanese only), but only limited information is available. More information on the corporate number (JCN) can be found here - http://www.nta.go.jp/foreign_language/corporate_number/ (National Tax Agency website). "
-    },
-    "formerPrefixes": [],
-    "links": {
-        "opencorporates": "",
-        "wikipedia": ""
-    },
-    "listType": "primary",
-    "meta": {
-        "lastUpdated": "2017-10-24",
-        "source": "ProZorro Business Register Research"
-    },
-    "name": {
-        "en": "JCN (Japanese Corporate Number). Japanese Corporate Registry - Houjintouki",
-        "local": "\u6cd5\u4eba\u767b\u8a18)"
-    },
-    "sector": [],
-    "structure": [
-        "company"
-    ],
-    "subnationalCoverage": [],
-    "url": "http://www.houjin-bangou.nta.go.jp/"
+  "name": {
+    "en": "National Tax Agency Corporate Number Publication Site",
+    "local": "法人登記)"
+  },
+  "url": "http://www.houjin-bangou.nta.go.jp/",
+  "description": {
+    "en": "On this website, the Corporate Number of each organization that has such number designated, and the name and the address of the head office or principal place of business of each organization that has registered its indications in English are made public. \nThe registry is open and searchable by Japanese Corporate Number (JCN) (in Japanese only), but only limited information is available. More information on the corporate number (JCN) can be found here - http://www.nta.go.jp/foreign_language/corporate_number/ (National Tax Agency website). "
+  },
+  "coverage": [
+    "JP"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "company"
+  ],
+  "sector": [],
+  "code": "JP-JCN",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Company can be searched by legal name and corporate number. Search results provide corporate number, name, address, change history information. English interface available, search is free of charge. ",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "3000020278670",
+    "languages": [
+      "jp",
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "open_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "ProZorro Business Register Research",
+    "lastUpdated": "2017-10-24"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
 }

--- a/lists/jp/jp-jcn.json
+++ b/lists/jp/jp-jcn.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": true,
+        "exampleIdentifiers": "7010001008844",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "Company can be searched by legal name and corporate number. Search results provide corporate number, name, address, change history information. English interface available, search is free of charge. ",
+        "publicDatabase": ""
+    },
+    "code": "JP-JCN",
+    "confirmed": true,
+    "coverage": [
+        "JP"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "A code allocated to a company by the Japanese National Tax Agency. The registry itself is open and searchable by JCN (in Japanese only), but only limited information is available. More information on the corporate number (JCN) can be found here - http://www.nta.go.jp/foreign_language/corporate_number/ (National Tax Agency website). "
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "primary",
+    "meta": {
+        "lastUpdated": "2017-10-24",
+        "source": "ProZorro Business Register Research"
+    },
+    "name": {
+        "en": "JCN (Japanese Corporate Number). Japanese Corporate Registry - Houjintouki",
+        "local": "\u6cd5\u4eba\u767b\u8a18)"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "http://www.houjin-bangou.nta.go.jp/"
+}


### PR DESCRIPTION
A new list has been proposed with the code JP-JCN

**List title:** National Tax Agency Corporate Number Publication Site

Reviewed

 Preview the platform with this list at [http://org-id.guide/_preview_branch/JP-JCN](http://org-id.guide/_preview_branch/JP-JCN)  (visiting [http://org-id.guide/list/JP-JCN](http://org-id.guide/list/JP-JCN) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.