### PR TITLE
New  registry entry for 'Tax Identification Number (Slovenia)' (SI-TIN)

### DIFF
--- a/lists/si/si-tin.json
+++ b/lists/si/si-tin.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": true,
+        "exampleIdentifiers": "59053283",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "",
+        "publicDatabase": ""
+    },
+    "code": "SI-TIN",
+    "confirmed": true,
+    "coverage": [
+        "SI"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "A unique code every legal entity or an individual enterpreneur must obtain."
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "secondary",
+    "meta": {
+        "lastUpdated": "2017-10-24",
+        "source": "ProZorro Business Register Research"
+    },
+    "name": {
+        "en": "Tax Identification Number",
+        "local": "Dav\u010dna \u0161tevilka"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "http://www.ajpes.eu/prs/"
+}

--- a/lists/si/si-tin.json
+++ b/lists/si/si-tin.json
@@ -1,48 +1,51 @@
 {
-    "access": {
-        "availableOnline": true,
-        "exampleIdentifiers": "59053283",
-        "guidanceOnLocatingIds": "",
-        "languages": [
-            ""
-        ],
-        "onlineAccessDetails": "",
-        "publicDatabase": ""
-    },
-    "code": "SI-TIN",
-    "confirmed": true,
-    "coverage": [
-        "SI"
+  "name": {
+    "en": "Tax Identification Number (Slovenia)",
+    "local": "Davčna številka"
+  },
+  "url": "https://www.ajpes.eu/",
+  "description": {
+    "en": "A unique tax identifier code (Davčna številka) which every legal entity or an individual entrepreneur must obtain.\n\nThese are entered on to the Slovenian Business Register (Poslovni register Slovenije)"
+  },
+  "coverage": [
+    "SI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "company"
+  ],
+  "sector": [],
+  "code": "SI-TIN",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "You will need to register (free) and log in to the business register to perform a search.",
+    "publicDatabase": "https://www.ajpes.eu/pru/",
+    "guidanceOnLocatingIds": "Use the Tax Number, including any non-numerical digits that appear as part of the code.\n\nSome tax identifiers are displayed on the website with spaces in the number. All the spaces should be removed when making use of the number within an identifier.",
+    "exampleIdentifiers": "90493826, 78310130, SI99190591, SI43301673",
+    "languages": [
+      "SL",
+      "EN"
+    ]
+  },
+  "data": {
+    "availability": [
+      "bulk"
     ],
-    "data": {
-        "availability": [],
-        "dataAccessDetails": "",
-        "features": [],
-        "licenseDetails": "",
-        "licenseStatus": "open_license"
-    },
-    "deprecated": false,
-    "description": {
-        "en": "A unique code every legal entity or an individual enterpreneur must obtain."
-    },
-    "formerPrefixes": [],
-    "links": {
-        "opencorporates": "",
-        "wikipedia": ""
-    },
-    "listType": "secondary",
-    "meta": {
-        "lastUpdated": "2017-10-24",
-        "source": "ProZorro Business Register Research"
-    },
-    "name": {
-        "en": "Tax Identification Number",
-        "local": "Dav\u010dna \u0161tevilka"
-    },
-    "sector": [],
-    "structure": [
-        "company"
-    ],
-    "subnationalCoverage": [],
-    "url": "http://www.ajpes.eu/prs/"
+    "dataAccessDetails": "From a paid service https://www.ajpes.si/registri/poslovni_register/splosno#",
+    "features": [],
+    "licenseStatus": "closed_license",
+    "licenseDetails": "https://www.ajpes.si/Registri/Poslovni_register/Ponovna_uporaba#b164"
+  },
+  "meta": {
+    "source": "ProZorro Business Register Research",
+    "lastUpdated": "2017-11-08"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
 }


### PR DESCRIPTION
A new list has been proposed with the code SI-TIN

**List title:** Tax Identification Number (Slovenia)

 Preview the platform with this list at [http://org-id.guide/_preview_branch/SI-TIN](http://org-id.guide/_preview_branch/SI-TIN)  (visiting [http://org-id.guide/list/SI-TIN](http://org-id.guide/list/SI-TIN) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.