### PR TITLE
Updated  registry entry for 'Mozambique Ministry of Justice' (MZ-MOJ)

### DIFF
--- a/lists/mz/mz-moj.json
+++ b/lists/mz/mz-moj.json
@@ -18,7 +18,7 @@
   "code": "MZ-MOJ",
   "confirmed": true,
   "deprecated": false,
-  "listType": "Primary",
+  "listType": "primary",
   "access": {
     "availableOnline": false,
     "onlineAccessDetails": null,


### PR DESCRIPTION
An update to the list with code MZ-MOJ has been proposed

**List title:** Mozambique Ministry of Justice

 Preview the platform with this list at [http://org-id.guide/_preview_branch/MZ-MOJ](http://org-id.guide/_preview_branch/MZ-MOJ)  (visiting [http://org-id.guide/list/MZ-MOJ](http://org-id.guide/list/MZ-MOJ) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.