### PR TITLE
New  registry entry for 'Taxpayer Single Identification Number (Mozambique)' (MZ-NUIT)

### DIFF
--- a/lists/mz/mz-nuit.json
+++ b/lists/mz/mz-nuit.json
@@ -1,0 +1,47 @@
+{
+  "name": {
+    "en": "Taxpayer Single Identification Number (Mozambique)",
+    "local": ""
+  },
+  "url": "http://www.at.gov.mz/eng/Internacional-Trade/FAQ-s/NUIT",
+  "description": {
+    "en": "NUIT is the Mozambique Taxpayer Single Identification Number.\n\nIt is made up of 9 digits split into 3 parts: the first digit stands for the type of entity, the middle part is a sequential number, and the last digit provides a checksum. \n\nBoth individuals and corporate entities are assigned an NUIT. "
+  },
+  "coverage": [
+    "MZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [],
+  "sector": [],
+  "code": "MZ-NUIT",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "Ask each organisation for a record of it's NUIT. ",
+    "exampleIdentifiers": "",
+    "languages": [
+      "en",
+      "pt"
+    ]
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "https://github.com/org-id/register/issues/129",
+    "lastUpdated": "2011-11-21"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mz/mz-nuit.json
+++ b/lists/mz/mz-nuit.json
@@ -1,7 +1,7 @@
 {
   "name": {
     "en": "Taxpayer Single Identification Number (Mozambique)",
-    "local": ""
+    "local": "Número Unico de Identificacao Tributaria"
   },
   "url": "http://www.at.gov.mz/eng/Internacional-Trade/FAQ-s/NUIT",
   "description": {


### PR DESCRIPTION
A new list has been proposed with the code MZ-NUIT

**List title:** Taxpayer Single Identification Number (Mozambique)

Created to address #129 

 Preview the platform with this list at [http://org-id.guide/_preview_branch/MZ-NUIT](http://org-id.guide/_preview_branch/MZ-NUIT)  (visiting [http://org-id.guide/list/MZ-NUIT](http://org-id.guide/list/MZ-NUIT) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.