### PR TITLE
New  registry entry for 'List of legal department names (Government of Canada)' (CA-GOV)

### DIFF
--- a/lists/ca/ca-gov.json
+++ b/lists/ca/ca-gov.json
@@ -1,0 +1,53 @@
+{
+  "name": {
+    "en": "List of legal department names (Government of Canada)",
+    "local": "Liste d’appellation légale des ministères "
+  },
+  "url": "http://open.canada.ca/data/en/dataset/22090865-f8a6-4b83-9bad-e9d61f26a821",
+  "description": {
+    "en": "\"The dataset includes a list of legal department names and their respective numbers. The department number is assigned by the Receiver General to an organization listed in Schedules I, 1.1 and II of the Financial Administration Act authorized to use the Consolidated Revenue Fund and interface with the central systems operated by Public Works and Government Services Canada.\""
+  },
+  "coverage": [
+    "CA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CA-GOV",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "CSV and Excel versions of the list are available for download. ",
+    "publicDatabase": "http://open.canada.ca/data/en/dataset/22090865-f8a6-4b83-9bad-e9d61f26a821",
+    "guidanceOnLocatingIds": "Identifiers are in the \"Department_number-Ministère_numéro\" column in the downloadable spreadsheet.",
+    "exampleIdentifiers": "001, 097, 124",
+    "languages": [
+      "en",
+      "fr"
+    ]
+  },
+  "data": {
+    "availability": [
+      "bulk",
+      "csv",
+      "excel"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "open_license",
+    "licenseDetails": "Open Government Licence - Canada"
+  },
+  "meta": {
+    "source": "http://open.canada.ca/",
+    "lastUpdated": "2017-11-28"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ca/ca-gov.json
+++ b/lists/ca/ca-gov.json
@@ -1,48 +1,45 @@
 {
   "name": {
-    "en": "List of legal department names (Government of Canada)",
-    "local": "Liste d’appellation légale des ministères "
+    "en": "Private Voluntary Organisations Council (Zimbabwe)",
+    "local": ""
   },
-  "url": "http://open.canada.ca/data/en/dataset/22090865-f8a6-4b83-9bad-e9d61f26a821",
+  "url": "",
   "description": {
-    "en": "\"The dataset includes a list of legal department names and their respective numbers. The department number is assigned by the Receiver General to an organization listed in Schedules I, 1.1 and II of the Financial Administration Act authorized to use the Consolidated Revenue Fund and interface with the central systems operated by Public Works and Government Services Canada.\""
+    "en": "\"NGOs in Zimbabwe are mainly registered under the Private Voluntary Organization Act (PVO Act). Registration is done through the Department of Social Welfare under the Ministry of Public Service Labour and Social Welfare.\" [1]\n\n[1] http://www.kanokangalawfirm.net/setting-ngo-zimbabwe/"
   },
   "coverage": [
-    "CA"
+    "ZW"
   ],
   "subnationalCoverage": [],
   "structure": [
-    "government_agency"
+    "charity"
   ],
   "sector": [],
-  "code": "CA-GOV",
+  "code": "ZW-PVO",
   "confirmed": true,
   "deprecated": false,
-  "listType": "secondary",
+  "listType": "primary",
   "access": {
-    "availableOnline": true,
-    "onlineAccessDetails": "CSV and Excel versions of the list are available for download. ",
-    "publicDatabase": "http://open.canada.ca/data/en/dataset/22090865-f8a6-4b83-9bad-e9d61f26a821",
-    "guidanceOnLocatingIds": "Identifiers are in the \"Department_number-Ministère_numéro\" column in the downloadable spreadsheet.",
-    "exampleIdentifiers": "001, 097, 124",
+    "availableOnline": false,
+    "onlineAccessDetails": null,
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "Identifiers are not available online. Organizations should have a \"PVO Registered Number\" on their registration paperwork. Ask the organization to supply this.",
+    "exampleIdentifiers": "15/2003, 42/10 ",
     "languages": [
-      "en",
-      "fr"
+      ""
     ]
   },
   "data": {
     "availability": [
-      "bulk",
-      "csv",
-      "excel"
+      "data_not_available"
     ],
     "dataAccessDetails": "",
     "features": [],
-    "licenseStatus": "open_license",
-    "licenseDetails": "Open Government Licence - Canada"
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
   },
   "meta": {
-    "source": "http://open.canada.ca/",
+    "source": "IATI Registration Agency List",
     "lastUpdated": "2017-11-28"
   },
   "links": {

--- a/lists/ca/ca-gov.json
+++ b/lists/ca/ca-gov.json
@@ -1,45 +1,48 @@
 {
   "name": {
-    "en": "Private Voluntary Organisations Council (Zimbabwe)",
-    "local": ""
+    "en": "List of legal department names (Government of Canada)",
+    "local": "Liste d’appellation légale des ministères "
   },
-  "url": "",
+  "url": "http://open.canada.ca/data/en/dataset/22090865-f8a6-4b83-9bad-e9d61f26a821",
   "description": {
-    "en": "\"NGOs in Zimbabwe are mainly registered under the Private Voluntary Organization Act (PVO Act). Registration is done through the Department of Social Welfare under the Ministry of Public Service Labour and Social Welfare.\" [1]\n\n[1] http://www.kanokangalawfirm.net/setting-ngo-zimbabwe/"
+    "en": "\"The dataset includes a list of legal department names and their respective numbers. The department number is assigned by the Receiver General to an organization listed in Schedules I, 1.1 and II of the Financial Administration Act authorized to use the Consolidated Revenue Fund and interface with the central systems operated by Public Works and Government Services Canada.\""
   },
   "coverage": [
-    "ZW"
+    "CA"
   ],
   "subnationalCoverage": [],
   "structure": [
-    "charity"
+    "government_agency"
   ],
   "sector": [],
-  "code": "ZW-PVO",
+  "code": "CA-GOV",
   "confirmed": true,
   "deprecated": false,
-  "listType": "primary",
+  "listType": "secondary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": null,
-    "publicDatabase": "",
-    "guidanceOnLocatingIds": "Identifiers are not available online. Organizations should have a \"PVO Registered Number\" on their registration paperwork. Ask the organization to supply this.",
-    "exampleIdentifiers": "15/2003, 42/10 ",
+    "availableOnline": true,
+    "onlineAccessDetails": "CSV and Excel versions of the list are available for download. ",
+    "publicDatabase": "http://open.canada.ca/data/en/dataset/22090865-f8a6-4b83-9bad-e9d61f26a821",
+    "guidanceOnLocatingIds": "Identifiers are in the \"Department_number-Ministère_numéro\" column in the downloadable spreadsheet.",
+    "exampleIdentifiers": "001, 097, 124",
     "languages": [
-      ""
+      "en",
+      "fr"
     ]
   },
   "data": {
     "availability": [
-      "data_not_available"
+      "bulk",
+      "csv",
+      "excel"
     ],
     "dataAccessDetails": "",
     "features": [],
-    "licenseStatus": "no_license",
-    "licenseDetails": ""
+    "licenseStatus": "open_license",
+    "licenseDetails": "Open Government Licence - Canada"
   },
   "meta": {
-    "source": "IATI Registration Agency List",
+    "source": "http://open.canada.ca/",
     "lastUpdated": "2017-11-28"
   },
   "links": {


### PR DESCRIPTION
A new list has been proposed with the code CA-GOV

**List title:** List of legal department names (Government of Canada)

Adding the list used by Public Works Canada, and currently being promoted for use across Canadian Government. 

 Preview the platform with this list at [http://org-id.guide/_preview_branch/CA-GOV](http://org-id.guide/_preview_branch/CA-GOV)  (visiting [http://org-id.guide/list/CA-GOV](http://org-id.guide/list/CA-GOV) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.