### PR TITLE
New  registry entry for 'Business Registration Number (Organisationsnummer), Sweden' (SE-ON)

### DIFF
--- a/lists/se/se-blv.json
+++ b/lists/se/se-blv.json
@@ -30,7 +30,7 @@
             "html"
         ]
     },
-    "deprecated": null,
+    "deprecated": true,
     "structure": [
         "company"
     ],

--- a/lists/se/se-kk.json
+++ b/lists/se/se-kk.json
@@ -18,7 +18,7 @@
   "sector": [],
   "code": "SE-KK",
   "confirmed": true,
-  "deprecated": false,
+  "deprecated": true,
   "listType": "secondary",
   "access": {
     "availableOnline": false,

--- a/lists/se/se-on.json
+++ b/lists/se/se-on.json
@@ -22,7 +22,7 @@
   "listType": "primary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "The business register can be accessed for free through the Bolagsverket search interface https://snr4.bolagsverket.se/snrgate/startIn.do or http://www.bolagsverket.se/en/us/about/e-services/foretagsfakta. Users can search for a company by name, or by their organisationsnummer and find basic information without registering.\n\nAn alternative free-online name checker can be found at https://www.verksamt.se/sok-foretagsnamn",
+    "onlineAccessDetails": "The business register can be accessed for free through the Bolagsverket search interface https://snr4.bolagsverket.se/snrgate/startIn.do or http://www.bolagsverket.se/en/us/about/e-services/foretagsfakta. Users can search for a organisation by name, or by their organisationsnummer and find basic information without registering.\n\nAn alternative free-online name checker can be found at https://www.verksamt.se/sok-foretagsnamn\n\nThe Swedish Tax Agency (Skatteverket) searches in the reverse manner: an organisationsnummer can be confirmed to be that of a particular organisation.",
     "publicDatabase": "https://snr4.bolagsverket.se/snrgate/startIn.do",
     "guidanceOnLocatingIds": "Look for an organisationsnummer (or registration number) which is a 10-digit number in the format 000000-0000",
     "exampleIdentifiers": "556091-2148, 556012-5790",
@@ -40,7 +40,7 @@
   },
   "meta": {
     "source": "Desk research",
-    "lastUpdated": "2017-11-07"
+    "lastUpdated": "2017-11-08"
   },
   "links": {
     "opencorporates": "",

--- a/lists/se/se-on.json
+++ b/lists/se/se-on.json
@@ -42,5 +42,8 @@
     "opencorporates": "",
     "wikipedia": "https://sv.wikipedia.org/wiki/Organisationsnummer#Organisationsnummer"
   },
-  "formerPrefixes": []
+  "formerPrefixes": [
+    "SE-KK",
+    "SE-BLV"
+  ]
 }

--- a/lists/se/se-on.json
+++ b/lists/se/se-on.json
@@ -1,34 +1,37 @@
 {
   "name": {
-    "en": "Organization Number (Sweden)",
-    "local": "Organisationsnummer (Sverige)"
+    "en": "Business Registration Number (Organisationsnummer), Sweden",
+    "local": "Organisationsnummer, Sverige"
   },
-  "url": "",
+  "url": "http://www.bolagsverket.se/ff/foretagsformer/organisationsnummer-1.7902",
   "description": {
-    "en": "\"The organization number is a unique identifier assigned to legal entities, such as companies and associations. \n\nThe authority that registers the company or association when it is to be started assigns the organizational number. Most companies and associations have their organization number from the Swedish Companies Registration Office [Bolagsverket http://www.bolagsverket.se]. But also, for example, the Swedish Tax Agency and Land Survey allocate organizational numbers.\n\nFrom the Swedish Companies Registration Office, the company or association has its organization number when we have decided to register. The organization number is on the registration certificate that we send out.\"[1]\n\n[1] http://www.bolagsverket.se/ff/foretagsformer/organisationsnummer-1.7902"
+    "en": "\"The organization number is a unique identifier assigned to legal entities, such as companies and associations. \n\nThe authority that registers the company or association when it is to be started assigns the organizational number. Most companies and associations have their organization number from the Swedish Companies Registration Office [Bolagsverket http://www.bolagsverket.se]. But also, for example, the Swedish Tax Agency and Land Survey allocate organizational numbers.\n\nFrom the Swedish Companies Registration Office, the company or association has its organization number when we have decided to register. The organization number is on the registration certificate that we send out.\"[1]\n\n\"The first digit of the organization number is called \"Group Number\" and specifies the company form or other legal form to which the legal entity is grouped. The following group numbers may occur.\n\n1 - Death certificate\n2 - State, county council, municipalities, parishes\n3 - Foreign companies engaged in business activities or own real estate in Sweden\n5 - Aktiebolag\n6 - Single company\n7 - Economic associations , tenant-owner associations\n8 - Ideal associations and foundations\n9 - Trading companies , limited companies and simple companies\"[2]\n\n[1] http://www.bolagsverket.se/ff/foretagsformer/organisationsnummer-1.7902\n[2] https://sv.wikipedia.org/wiki/Organisationsnummer#Organisationsnummer"
   },
-  "coverage": [],
+  "coverage": [
+    "SE"
+  ],
   "subnationalCoverage": [],
   "structure": [],
   "sector": [],
-  "code": "",
-  "confirmed": false,
+  "code": "SE-ON",
+  "confirmed": true,
   "deprecated": false,
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "",
-    "publicDatabase": "",
-    "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
+    "availableOnline": true,
+    "onlineAccessDetails": "The business register can be accessed for free through the Bolagsverket search interface https://snr4.bolagsverket.se/snrgate/startIn.do or http://www.bolagsverket.se/en/us/about/e-services/foretagsfakta. Users can search for a company by name, or by their organisationsnummer and find basic information without registering.\n\nAn alternative free-online name checker can be found at https://www.verksamt.se/sok-foretagsnamn",
+    "publicDatabase": "https://snr4.bolagsverket.se/snrgate/startIn.do",
+    "guidanceOnLocatingIds": "Look for an organisationsnummer (or registration number) which is in the format 000000-0000",
+    "exampleIdentifiers": "556091-2148, 556012-5790",
     "languages": [
-      ""
+      "SE"
     ]
   },
   "data": {
-    "availability": [],
+    "availability": [
+      "data_not_available"
+    ],
     "dataAccessDetails": "",
     "features": [],
-    "licenseStatus": "open_license",
     "licenseDetails": ""
   },
   "meta": {
@@ -37,7 +40,7 @@
   },
   "links": {
     "opencorporates": "",
-    "wikipedia": ""
+    "wikipedia": "https://sv.wikipedia.org/wiki/Organisationsnummer#Organisationsnummer"
   },
   "formerPrefixes": []
 }

--- a/lists/se/se-on.json
+++ b/lists/se/se-on.json
@@ -20,7 +20,7 @@
     "availableOnline": true,
     "onlineAccessDetails": "The business register can be accessed for free through the Bolagsverket search interface https://snr4.bolagsverket.se/snrgate/startIn.do or http://www.bolagsverket.se/en/us/about/e-services/foretagsfakta. Users can search for a company by name, or by their organisationsnummer and find basic information without registering.\n\nAn alternative free-online name checker can be found at https://www.verksamt.se/sok-foretagsnamn",
     "publicDatabase": "https://snr4.bolagsverket.se/snrgate/startIn.do",
-    "guidanceOnLocatingIds": "Look for an organisationsnummer (or registration number) which is in the format 000000-0000",
+    "guidanceOnLocatingIds": "Look for an organisationsnummer (or registration number) which is a 10-digit number in the format 000000-0000",
     "exampleIdentifiers": "556091-2148, 556012-5790",
     "languages": [
       "SE"

--- a/lists/se/se-on.json
+++ b/lists/se/se-on.json
@@ -19,6 +19,7 @@
   "code": "SE-ON",
   "confirmed": true,
   "deprecated": false,
+  "listType": "primary",
   "access": {
     "availableOnline": true,
     "onlineAccessDetails": "The business register can be accessed for free through the Bolagsverket search interface https://snr4.bolagsverket.se/snrgate/startIn.do or http://www.bolagsverket.se/en/us/about/e-services/foretagsfakta. Users can search for a company by name, or by their organisationsnummer and find basic information without registering.\n\nAn alternative free-online name checker can be found at https://www.verksamt.se/sok-foretagsnamn",

--- a/lists/se/se-on.json
+++ b/lists/se/se-on.json
@@ -11,7 +11,10 @@
     "SE"
   ],
   "subnationalCoverage": [],
-  "structure": [],
+  "structure": [
+    "company",
+    "trust"
+  ],
   "sector": [],
   "code": "SE-ON",
   "confirmed": true,

--- a/lists/se/se-on.json
+++ b/lists/se/se-on.json
@@ -1,0 +1,43 @@
+{
+  "name": {
+    "en": "Organization Number (Sweden)",
+    "local": "Organisationsnummer (Sverige)"
+  },
+  "url": "",
+  "description": {
+    "en": "\"The organization number is a unique identifier assigned to legal entities, such as companies and associations. \n\nThe authority that registers the company or association when it is to be started assigns the organizational number. Most companies and associations have their organization number from the Swedish Companies Registration Office [Bolagsverket http://www.bolagsverket.se]. But also, for example, the Swedish Tax Agency and Land Survey allocate organizational numbers.\n\nFrom the Swedish Companies Registration Office, the company or association has its organization number when we have decided to register. The organization number is on the registration certificate that we send out.\"[1]\n\n[1] http://www.bolagsverket.se/ff/foretagsformer/organisationsnummer-1.7902"
+  },
+  "coverage": [],
+  "subnationalCoverage": [],
+  "structure": [],
+  "sector": [],
+  "code": "",
+  "confirmed": false,
+  "deprecated": false,
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": [
+      ""
+    ]
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "open_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2017-11-07"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}


### PR DESCRIPTION
A new list has been proposed with the code SE-ON

**List title:** Business Registration Number (Organisationsnummer), Sweden

addition of SE-ON, deprecation of SE-KK and SE-BLV

 Preview the platform with this list at [http://org-id.guide/_preview_branch/SE-ON](http://org-id.guide/_preview_branch/SE-ON)  (visiting [http://org-id.guide/list/SE-ON](http://org-id.guide/list/SE-ON) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.