### PR TITLE
New  registry entry for 'testwlist' (GB-TEST)

### DIFF
--- a/lists/gb/gb-test.json
+++ b/lists/gb/gb-test.json
@@ -1,0 +1,43 @@
+{
+  "name": {
+    "en": "testwlist",
+    "local": ""
+  },
+  "url": "",
+  "description": {
+    "en": ""
+  },
+  "coverage": [],
+  "subnationalCoverage": [],
+  "structure": [],
+  "sector": [],
+  "code": "",
+  "confirmed": false,
+  "deprecated": false,
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": [
+      ""
+    ]
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "open_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "",
+    "lastUpdated": ""
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gb/gb-test.json
+++ b/lists/gb/gb-test.json
@@ -7,12 +7,14 @@
   "description": {
     "en": ""
   },
-  "coverage": [],
+  "coverage": [
+    "GB"
+  ],
   "subnationalCoverage": [],
   "structure": [],
   "sector": [],
-  "code": "",
-  "confirmed": false,
+  "code": "GB-TEST",
+  "confirmed": true,
   "deprecated": false,
   "access": {
     "availableOnline": false,


### PR DESCRIPTION
A new list has been proposed with the code GB-TEST

**List title:** testwlist

 Preview the platform with this list at [http://org-id.guide/_preview_branch/GB-TEST](http://org-id.guide/_preview_branch/GB-TEST)  (visiting [http://org-id.guide/list/GB-TEST](http://org-id.guide/list/GB-TEST) when the preview is active or check the files changed options above.

This is considered a minor change, and so will be merged shortly, but may be reverted if objections are raised in the next 7 days.