### PR TITLE
New  registry entry for 'Newlist2' (GB-TEST2)

### DIFF
--- a/lists/gb/gb-test2.json
+++ b/lists/gb/gb-test2.json
@@ -1,0 +1,43 @@
+{
+  "name": {
+    "en": "Newlist2",
+    "local": ""
+  },
+  "url": "",
+  "description": {
+    "en": ""
+  },
+  "coverage": [],
+  "subnationalCoverage": [],
+  "structure": [],
+  "sector": [],
+  "code": "GB-TEST2",
+  "confirmed": true,
+  "deprecated": false,
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": [
+      ""
+    ]
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "open_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "",
+    "lastUpdated": ""
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gb/gb-test2.json
+++ b/lists/gb/gb-test2.json
@@ -1,6 +1,6 @@
 {
   "name": {
-    "en": "Newlist2",
+    "en": "Newlist21",
     "local": ""
   },
   "url": "",


### PR DESCRIPTION
A new list has been proposed with the code GB-TEST2

**List title:** Newlist2

 Preview the platform with this list at [http://org-id.guide/_preview_branch/GB-TEST2](http://org-id.guide/_preview_branch/GB-TEST2)  (visiting [http://org-id.guide/list/GB-TEST2](http://org-id.guide/list/GB-TEST2) when the preview is active or check the files changed options above.

This is considered a minor change, and so will be merged shortly, but may be reverted if objections are raised in the next 7 days.