### PR TITLE
New registry entry for 'Global Research Identifier Database' (XI-GRID)

### DIFF
--- a/lists/xi/xi-grid.json
+++ b/lists/xi/xi-grid.json
@@ -15,7 +15,7 @@
     "coverage": null,
     "code": "XI-GRID",
     "formerPrefixes": null,
-    "confirmed": null,
+    "confirmed": true,
     "data": {
         "features": [
             "contact_address",


### PR DESCRIPTION
A new list has been proposed with the code XI-GRID

List title: Global Research Identifier Database

Preview the platform with this list at http://dev.org-id.guide/_preview_branch/XI-GRID (visiting http://dev.org-id.guide/list/XI-GRID when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.