### PR TITLE
New  registry entry for 'Registro de Personas Jurídicas (Costa Rica)' (CR-RPJ)

### DIFF
--- a/lists/cr/cr-rpj.json
+++ b/lists/cr/cr-rpj.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Registro de Personas Jurídicas (Costa Rica)",
+    "local": "Registro de Personas Jurídicas (Costa Rica)"
+  },
+  "url": "http://www.registronacional.go.cr/",
+  "description": {
+    "en": "Companies and foundations may be registered with the Registro de Personas Jurídicas managed by the National Registry (Registro Nacional). \n\nNumbers are assigned in with the structure N-NNN-NNNNNN. Sometimes, these are written without leading zeros for the second set of numbers, but in org-id.guide the leading zeros should be include (e.g. 3-001-111111 rather than 3-1-1111111). \n"
+  },
+  "coverage": [
+    "CR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity",
+    "company"
+  ],
+  "sector": [],
+  "code": "CR-RPJ",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "A free online search by organisation name is available (after free registration) through the https://www.rnpdigital.com/ platform (Under 'Consultas Gratuitas > Consulta por Nombre Social')",
+    "publicDatabase": "https://www.rnpdigital.com/",
+    "guidanceOnLocatingIds": "Use the search at https://www.rnpdigital.com/ after registering and logging in. This is accessed from the  'Consultas Gratuitas' menu, and then the 'Consulta por Nombre Social' option.\n\nThe name to search for is entered into the 'Buscar Por', and a captcha completed to allow search.\n\nIn the search results, click the value in the 'Identificación' column to get the full identifier (CEDULA JURÍDICA). ",
+    "exampleIdentifiers": "3-006-125548, 3-101-711395, 3-102-742470",
+    "languages": [
+      "es"
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "https://github.com/org-id/register/issues/235",
+    "lastUpdated": "2018-07-13"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}


### PR DESCRIPTION
A new list has been proposed with the code CR-RPJ

**List title:** Registro de Personas Jurídicas (Costa Rica)

Addresses #235 

 Preview the platform with this list at [http://org-id.guide/_preview_branch/CR-RPJ](http://org-id.guide/_preview_branch/CR-RPJ)  (visiting [http://org-id.guide/list/CR-RPJ](http://org-id.guide/list/CR-RPJ) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.