### PR TITLE
Updated  registry entry for 'Afghanistan Central Business Registry' (AF-CBR)

### DIFF
--- a/lists/af/af-cbr.json
+++ b/lists/af/af-cbr.json
@@ -1,51 +1,58 @@
 {
-    "links": {
-        "wikipedia": null,
-        "opencorporates": null
-    },
-    "sector": null,
-    "url": "http://acbr.gov.af/",
-    "name": {
-        "en": "Afghanistan Central Business Registry",
-        "local": ""
-    },
-    "coverage": [
-        "AF"
+  "name": {
+    "en": "Afghanistan Central Business Registry",
+    "local": ""
+  },
+  "url": "http://acbr.gov.af/",
+  "description": {
+    "en": "The Afghan Central Business Registry is a service which allows a single place to register a business in Afghanistan. All companies, groups and individuals are required to register at the ACBR, where they receive confirmation of their registration, become published in the ACBR Gazette and receive the Tax Identification Number. \n\n\"The new Central Registry is a one stop shop to register your business. It brings together all of the functions previously done by the commercial courts, the Ministry of Justice and the Ministry of Finance.\" [1]\n\n\"ACBR exists to provide services to businesses in Afghanistan intending to register their names and protect their intellectual property rights.\" [2]\n\n\"All corporations, partnerships, limited liability companies and sole proprietorships doing Trade are required to register with ACBR, which facilitates the registration process, including assistance for completing the application form, paying fees, publishing key business information in the Official Gazette and reporting specification of businesses to the Revenue Department of MoF. Registration is required only one time unless a business makes major changes (i.e., change in ownership, executive management, or location or if the initial capital increases or decreases).\n\nBusinesses are referred to ACBR from either the Trader License office located in the Ministry of Commerce and Industry, from AISA, or from any other license departments after they acquire a business license.\" [3]\n\n[1] http://acbr.gov.af/FAQ.html\n[2] http://acbr.gov.af/index.html\n[3] http://acbr.gov.af/registration.html"
+  },
+  "coverage": [
+    "AF"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "company"
+  ],
+  "sector": [],
+  "code": "AF-CBR",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": null,
+    "publicDatabase": " https://www.acbrip.gov.af/companyverification/ ",
+    "guidanceOnLocatingIds": "An online search is available at  https://www.acbrip.gov.af/companyverification/ \n\nThis returns access to four identifiers (Reference, Registration, TIN Number, License).\n\nThe Registration Number should be used. ",
+    "exampleIdentifiers": "102164, 121048, 14941",
+    "languages": [
+      "en",
+      "ar"
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
     ],
-    "code": "AF-CBR",
-    "formerPrefixes": null,
-    "confirmed": true,
-    "data": {
-        "features": null,
-        "dataAccessDetails": null,
-        "licenseDetails": null,
-        "licenseStatus": "no_license",
-        "availability": [
-            "data_not_available"
-        ]
-    },
-    "deprecated": null,
-    "structure": [
-        "company"
+    "dataAccessDetails": "",
+    "features": [
+      "directors_trustees_governors",
+      "registered_address",
+      "industry_classifications",
+      "date_of_registration",
+      "registration_number",
+      "tax_id_number"
     ],
-    "description": {
-        "en": "The Afghan Central Business Registry is a service which allows a single place to register a business in Afghanistan. All companies, groups and individuals are required to register at the ACBR, where they receive confirmation of their registration, become published in the ACBR Gazette and receive the Tax Identification Number. \n\n\"The new Central Registry is a one stop shop to register your business. It brings together all of the functions previously done by the commercial courts, the Ministry of Justice and the Ministry of Finance.\" [1]\n\n\"ACBR exists to provide services to businesses in Afghanistan intending to register their names and protect their intellectual property rights.\" [2]\n\n\"All corporations, partnerships, limited liability companies and sole proprietorships doing Trade are required to register with ACBR, which facilitates the registration process, including assistance for completing the application form, paying fees, publishing key business information in the Official Gazette and reporting specification of businesses to the Revenue Department of MoF. Registration is required only one time unless a business makes major changes (i.e., change in ownership, executive management, or location or if the initial capital increases or decreases).\n\nBusinesses are referred to ACBR from either the Trader License office located in the Ministry of Commerce and Industry, from AISA, or from any other license departments after they acquire a business license.\" [3]\n\n[1] http://acbr.gov.af/FAQ.html\n[2] http://acbr.gov.af/index.html\n[3] http://acbr.gov.af/registration.html"
-    },
-    "meta": {
-        "lastUpdated": "2016-11-24",
-        "source": "Desk research"
-    },
-    "access": {
-        "languages": [
-            "en",
-            "ar"
-        ],
-        "exampleIdentifiers": null,
-        "onlineAccessDetails": null,
-        "publicDatabase": "Information about companies registered with ACBR is recorded in the Official Gazette (written in Arabic), but there is no public database - http://www.moj.gov.af/content/files/OfficialGazette/0401/OG_0455.pdf",
-        "availableOnline": false,
-        "guidanceOnLocatingIds": "The identifiers are the Tax Identification Numbers, but they are not publicly available."
-    },
-    "subnationalCoverage": null,
-    "listType": "primary"
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2018-07-24"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
 }


### PR DESCRIPTION
An update to the list with code AF-CBR has been proposed

**List title:** Afghanistan Central Business Registry

Updates to meta-data - closes #233

 Preview the platform with this list at [http://org-id.guide/_preview_branch/AF-CBR](http://org-id.guide/_preview_branch/AF-CBR)  (visiting [http://org-id.guide/list/AF-CBR](http://org-id.guide/list/AF-CBR) when the preview is active or check the files changed options above.

This is considered a minor change, and so will be merged shortly, but may be reverted if objections are raised in the next 7 days.