### PR TITLE
New  registry entry for 'Sri Lanka - National Secretariat for Non-Governmental Organisations' (LK-NGO)

### DIFF
--- a/lists/lk/lk-ngo.json
+++ b/lists/lk/lk-ngo.json
@@ -1,0 +1,50 @@
+{
+  "name": {
+    "en": "Sri Lanka - National Secretariat for Non-Governmental Organisations",
+    "local": ""
+  },
+  "url": "http://www.ngosecretariat.gov.lk/",
+  "description": {
+    "en": "The National Secretariat for Non-Governmental Organisations maintain a directory of registered NGOs. "
+  },
+  "coverage": [
+    "LK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity"
+  ],
+  "sector": [],
+  "code": "LK-NGO",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "A simple online directory providing registration numbers for currently active NGOs is available. ",
+    "publicDatabase": "http://www.ngosecretariat.gov.lk/web/",
+    "guidanceOnLocatingIds": "Search by name, and use the identifier in the 'Reg No' column.",
+    "exampleIdentifiers": "80505, 146512, 32912",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2018-09-24"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}


### PR DESCRIPTION
A new list has been proposed with the code LK-NGO

**List title:** Sri Lanka - National Secretariat for Non-Governmental Organisations

Discovered when carrying out research and added based on initial review.

 Preview the platform with this list at [http://org-id.guide/_preview_branch/LK-NGO](http://org-id.guide/_preview_branch/LK-NGO)  (visiting [http://org-id.guide/list/LK-NGO](http://org-id.guide/list/LK-NGO) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.