### PR TITLE
Updated  registry entry for 'National Bureau for NGOs (Uganda)' (UG-NGO)

### DIFF
--- a/lists/ug/ug-ngo.json
+++ b/lists/ug/ug-ngo.json
@@ -18,7 +18,7 @@
   "code": "UG-NGO",
   "confirmed": true,
   "deprecated": false,
-  "listType": "primary",
+  "listType": "secondary",
   "access": {
     "availableOnline": false,
     "onlineAccessDetails": "No online search of identifiers has been located. ",


### PR DESCRIPTION
An update to the list with code UG-NGO has been proposed

**List title:** National Bureau for NGOs (Uganda)

Updating to reflect that NGO register is a secondary status - not primary registration. 

 Preview the platform with this list at [http://org-id.guide/_preview_branch/UG-NGO](http://org-id.guide/_preview_branch/UG-NGO)  (visiting [http://org-id.guide/list/UG-NGO](http://org-id.guide/list/UG-NGO) when the preview is active or check the files changed options above.

This is considered a minor change, and so will be merged shortly, but may be reverted if objections are raised in the next 7 days.