### PR TITLE
Updated  registry entry for 'NGO Board, Ministry of Internal Affairs (Uganda)' (UG-NGB)

### DIFF
--- a/lists/ug/ug-ngb.json
+++ b/lists/ug/ug-ngb.json
@@ -1,56 +1,53 @@
 {
-    "links": {
-        "wikipedia": null,
-        "opencorporates": "http://opencorporates.com/companies/ug"
-    },
-    "sector": null,
-    "url": "http://www.mia.go.ug/?page_id=62",
-    "name": {
-        "en": "NGO Board, Ministry of Internal Affairs",
-        "local": ""
-    },
-    "coverage": [
-        "UG"
+  "name": {
+    "en": "NGO Board, Ministry of Internal Affairs (Uganda)",
+    "local": ""
+  },
+  "url": "http://www.mia.go.ug/?page_id=62",
+  "description": {
+    "en": "All NGOs wishing to operate in Uganda must register with the NGO Board of the Ministry of Internal Affairs. \n\n\"The National NGO Board under the Ministry of Internal Affairs, which is the lead Ministry, is legally mandated to register, regulate, coordinate and monitor NGOs in Uganda.\""
+  },
+  "coverage": [
+    "UG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity"
+  ],
+  "sector": [],
+  "code": "UG-NGB",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": null,
+    "publicDatabase": "http://brs.ursb.go.ug/brs/pro/bnr/searchname#SearchNamePub",
+    "guidanceOnLocatingIds": "Users can search for NGO identifiers on the Uganda Registration Services Bureau database.\n\nUsers should note that current research has not found this database to work when selecting 'NGO' on the 'Business type' drop-down menu. It is possible to search for NGO names and find results.\n\nUsers should be aware that identifiers are not formed in a uniform manner, and use slashes and hyphens.",
+    "exampleIdentifiers": "80010001803086/BN-55471 , R1000000336259 , 80010003208981/101303A",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "",
+    "features": [
+      "registration_number",
+      "date_of_registration",
+      "expiry_date",
+      "status"
     ],
-    "code": "UG-NGB",
-    "formerPrefixes": null,
-    "confirmed": true,
-    "data": {
-        "features": [
-            "registration_number",
-            "organisation_name",
-            "date_of_registration",
-            "expiry_date",
-            "status"
-        ],
-        "dataAccessDetails": null,
-        "licenseDetails": "https://opencorporates.com/registers/267",
-        "licenseStatus": "closed_license",
-        "availability": [
-            "available:_stated_as_available,_but_unable_to_access"
-        ]
-    },
-    "deprecated": null,
-    "structure": [
-        "charity"
-    ],
-    "description": {
-        "en": "All NGOs wishing to operate in Uganda must register with the NGO Board of the Ministry of Internal Affairs. \n\n\"The National NGO Board under the Ministry of Internal Affairs, which is the lead Ministry, is legally mandated to register, regulate, coordinate and monitor NGOs in Uganda.\""
-    },
-    "meta": {
-        "lastUpdated": "2016-12-19",
-        "source": null
-    },
-    "access": {
-        "languages": [
-            "en"
-        ],
-        "exampleIdentifiers": "80010001803086/BN-55471 , R1000000336259 , 80010003208981/101303A",
-        "onlineAccessDetails": null,
-        "publicDatabase": "http://brs.ursb.go.ug/brs/pro/bnr/searchname#SearchNamePub",
-        "availableOnline": false,
-        "guidanceOnLocatingIds": "Users can search for NGO identifiers on the Uganda Registration Services Bureau database.\n\nUsers should note that current research has not found this database to work when selecting 'NGO' on the 'Business type' drop-down menu. It is possible to search for NGO names and find results.\n\nUsers should be aware that identifiers are not formed in a uniform manner, and use slashes and hyphens."
-    },
-    "subnationalCoverage": null,
-    "listType": "secondary"
+    "licenseStatus": "closed_license",
+    "licenseDetails": "https://opencorporates.com/registers/267"
+  },
+  "meta": {
+    "source": "",
+    "lastUpdated": "2016-12-19"
+  },
+  "links": {
+    "opencorporates": "http://opencorporates.com/companies/ug",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
 }

--- a/lists/ug/ug-ngb.json
+++ b/lists/ug/ug-ngb.json
@@ -17,7 +17,7 @@
   "sector": [],
   "code": "UG-NGB",
   "confirmed": true,
-  "deprecated": false,
+  "deprecated": true,
   "listType": "secondary",
   "access": {
     "availableOnline": false,


### PR DESCRIPTION
An update to the list with code UG-NGB has been proposed

**List title:** NGO Board, Ministry of Internal Affairs (Uganda)

I'm proposing deprecation of this list, as it points to the same place as UG-RSB as the source of identifiers, and overlaps with UG-NGO. 

 Preview the platform with this list at [http://org-id.guide/_preview_branch/UG-NGB](http://org-id.guide/_preview_branch/UG-NGB)  (visiting [http://org-id.guide/list/UG-NGB](http://org-id.guide/list/UG-NGB) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.