### PR TITLE
Updated  registry entry for 'Example Data Prefix' (XE-EXAMPLE)

### DIFF
--- a/lists/xe/xe-example.json
+++ b/lists/xe/xe-example.json
@@ -1,7 +1,7 @@
 {
   "name": {
     "en": "Example Data Prefix",
-    "local": ""
+    "local": "en"
   },
   "url": "",
   "description": {


### PR DESCRIPTION
An update to the list with code XE-EXAMPLE has been proposed

**List title:** Example Data Prefix

demo pull request see #299

 Preview the platform with this list at [http://org-id.guide/_preview_branch/XE-EXAMPLE](http://org-id.guide/_preview_branch/XE-EXAMPLE)  (visiting [http://org-id.guide/list/XE-EXAMPLE](http://org-id.guide/list/XE-EXAMPLE) when the preview is active or check the files changed options above.

This is considered a minor change, and so will be merged shortly, but may be reverted if objections are raised in the next 7 days.