### PR TITLE
New  registry entry for 'Humanitarian Aid Commission' (SD-HAC)

### DIFF
--- a/lists/sd/sd-hac.json
+++ b/lists/sd/sd-hac.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Humanitarian Aid Commission",
+    "local": ""
+  },
+  "url": "",
+  "description": {
+    "en": "The Humanitarian Aid Commission is Sudan's governmental organisation for the co-ordination of voluntary humanitarian aid work. This includes the registration of charities, civil society and voluntary organisations.\n\nAn online resource has not been found. Verification is provided through the registration certificate of an organisation. Registrations have to be updated annually."
+  },
+  "coverage": [
+    "SD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity"
+  ],
+  "sector": [
+    "humantiarian_relief"
+  ],
+  "code": "SD-HAC",
+  "confirmed": false,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "The identifier is a number that appears on the right hand side of an organisation's registration certificate.",
+    "exampleIdentifiers": "45",
+    "languages": [
+      ""
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research prompted by a request for a unique identifier from a Sudanese NGO",
+    "lastUpdated": "2019-01-03"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}


### PR DESCRIPTION
A new list has been proposed with the code SD-HAC

**List title:** Humanitarian Aid Commission

requires confirmation of how identifiers are issued

 Preview the platform with this list at [http://org-id.guide/_preview_branch/SD-HAC](http://org-id.guide/_preview_branch/SD-HAC)  (visiting [http://org-id.guide/list/SD-HAC](http://org-id.guide/list/SD-HAC) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.