### PR TITLE
Updated  registry entry for 'NHS Digital - Organisation Data Service' (GB-NHS)

### DIFF
--- a/lists/gb/gb-nhs.json
+++ b/lists/gb/gb-nhs.json
@@ -12,7 +12,8 @@
   ],
   "subnationalCoverage": [],
   "structure": [
-    "government_agency/public_service"
+    "government_agency/public_service",
+    "government_agency"
   ],
   "sector": [],
   "code": "GB-NHS",
@@ -21,7 +22,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Download the relevant zipped files from https://digital.nhs.uk/organisation-data-service/data-downloads\n\nRegular users can also subscribe to the TRUD (Technology Reference Data Update Distribution) service to receive XML format updates of new distributions: https://isd.digital.nhs.uk/trud3/user/authenticated/group/0/pack/5 ",
+    "onlineAccessDetails": "Search across organisations and practitioners at https://odsportal.hscic.gov.uk/Organisation/Search. This also allows users to view each entry in more detail. It does not have a download facility. \n\nDownload the relevant zipped files from https://digital.nhs.uk/organisation-data-service/data-downloads\n\nRegular users can also subscribe to the TRUD (Technology Reference Data Update Distribution) service to receive XML format updates of new distributions: https://isd.digital.nhs.uk/trud3/user/authenticated/group/0/pack/5 ",
     "publicDatabase": "https://digital.nhs.uk/organisation-data-service/data-downloads",
     "guidanceOnLocatingIds": "In most cases, the organisation code is in the first column of each csv. A pdf is usually included in each distribution so that this can be confirmed, as there are no header rows in the datasets themselves.",
     "exampleIdentifiers": "01F, 7A1A5, Z1070, RAX",


### PR DESCRIPTION
An update to the list with code GB-NHS has been proposed

**List title:** NHS Digital - Organisation Data Service

update to include new search facility

 Preview the platform with this list at [http://org-id.guide/_preview_branch/GB-NHS](http://org-id.guide/_preview_branch/GB-NHS)  (visiting [http://org-id.guide/list/GB-NHS](http://org-id.guide/list/GB-NHS) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.