### PR TITLE
Updated  registry entry for 'Registrar General's Department' (GH-RGD)

### DIFF
--- a/lists/gh/gh-rgd.json
+++ b/lists/gh/gh-rgd.json
@@ -36,14 +36,13 @@
       "data_not_available"
     ],
     "dataAccessDetails": "",
-    "features": [
-    ],
+    "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""
   },
   "meta": {
     "source": "Desk research based on https://github.com/org-id/register/issues/333",
-    "lastUpdated": "2016-09-17"
+    "lastUpdated": "2019-04-29"
   },
   "links": {
     "opencorporates": "",


### PR DESCRIPTION
An update to the list with code GH-RGD has been proposed

**List title:** Registrar General's Department

ad hoc updated date correction

 Preview the platform with this list at [http://org-id.guide/_preview_branch/GH-RGD](http://org-id.guide/_preview_branch/GH-RGD)  (visiting [http://org-id.guide/list/GH-RGD](http://org-id.guide/list/GH-RGD) when the preview is active or check the files changed options above.

This is considered a minor change, and so will be merged shortly, but may be reverted if objections are raised in the next 7 days.