### PR TITLE
Updated  registry entry for 'Ministere de l'Administration Territoriale ' (ML-MAT)

### DIFF
--- a/lists/ml/ml-mat.json
+++ b/lists/ml/ml-mat.json
@@ -25,7 +25,7 @@
     "availableOnline": false,
     "onlineAccessDetails": "",
     "publicDatabase": "http://www.matcl.gov.ml/",
-    "guidanceOnLocatingIds": "An historic list is available (accessed 2019-05-13) through the menu item \"ASSOCIATIONS ET ONG\". This appears to have a different coding scheme to one shown in a certificate provided to org-id from 2016.",
+    "guidanceOnLocatingIds": "An organisation's registration certificate is the means by which their id can be determined.\nAn historic list is available (accessed 2019-05-13) through the menu item \"ASSOCIATIONS ET ONG\". This appears to have a different coding scheme to one shown in a certificate provided to org-id from 2016.",
     "exampleIdentifiers": "0003 (dated 2013), 0603-G-DB (dated 2016)",
     "languages": [
       "fr"


### PR DESCRIPTION
An update to the list with code ML-MAT has been proposed

**List title:** Ministere de l'Administration Territoriale 

adding means of determining an org's id

 Preview the platform with this list at [http://org-id.guide/_preview_branch/ML-MAT](http://org-id.guide/_preview_branch/ML-MAT)  (visiting [http://org-id.guide/list/ML-MAT](http://org-id.guide/list/ML-MAT) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.