### PR TITLE
New  registry entry for 'National Revenue Agency' (SL-TIN)

### DIFF
--- a/lists/sl/sl-tin.json
+++ b/lists/sl/sl-tin.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "National Revenue Agency",
+    "local": ""
+  },
+  "url": "https://nra.gov.sl/taxpayer-identification-number",
+  "description": {
+    "en": "The Taxpayer Identification Number, or TIN, is a unique computer-generated number allocated to each taxpayer, whether they are an individual, a commercial business, a Government department, public corporation, or a special body. As its name implies, the TIN identifies taxpayers for the purpose of all their tax and other revenue liabilities, including:\n\nGoods and Services Tax (GST)\nIncome Tax on personal income\nCorporation Tax\nCapital Gains Tax\nNon-tax revenues\nCustoms Duties\nExcise Duties\nProperty Tax\nThe TIN is also required for identification in all other transactions and dealings with the NRA"
+  },
+  "coverage": [
+    "SL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "company",
+    "government_agency",
+    "charity"
+  ],
+  "sector": [],
+  "code": "SL-TIN",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "",
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "Organisations receive a certificate recording their TIN. In the absence of an online, searchable list this should be the means of identification.",
+    "exampleIdentifiers": "",
+    "languages": [
+      ""
+    ]
+  },
+  "data": {
+    "availability": [
+      "data_not_available"
+    ],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "desk research",
+    "lastUpdated": "2019-06-03"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}


### PR DESCRIPTION
A new list has been proposed with the code SL-TIN

**List title:** National Revenue Agency

New list for Sierra Leone Taxpayer Identification Number

 Preview the platform with this list at [http://org-id.guide/_preview_branch/SL-TIN](http://org-id.guide/_preview_branch/SL-TIN)  (visiting [http://org-id.guide/list/SL-TIN](http://org-id.guide/list/SL-TIN) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.