### PR TITLE
Editing file to correct for confirmed: true

### DIFF
--- a/lists/al/al-qkb.json
+++ b/lists/al/al-qkb.json
@@ -18,7 +18,7 @@
   ],
   "sector": [],
   "code": "AL-QKB",
-  "confirmed": false,
+  "confirmed": true,
   "deprecated": false,
   "access": {
     "availableOnline": true,


### PR DESCRIPTION
Editing the file directly in the org-id repo rather than using the vagrantised org-ids option. This is intended to implement #298 