### PR TITLE
New  registry entry for 'Guatemala Tax Identification Number' (GT-NIT)

### DIFF
--- a/lists/gt/gt-nit.json
+++ b/lists/gt/gt-nit.json
@@ -1,0 +1,47 @@
+{
+  "name": {
+    "en": "Guatemala Tax Identification Number",
+    "local": "Número de Identificación Tributaria de Guatemala"
+  },
+  "url": "https://portal.sat.gob.gt/portal/",
+  "description": {
+    "en": "The Número de Identificación Tributaria (NIT) is a number assigned by the Superintendencia de Administración Tributaria in Guatemala to every tax payer, including both companies and individuals.\n\nCompanies must register with the Commercial Registry (Registro Mercantil) online at https://minegocio.gt/ to be incorporated and assigned an NIT number."
+  },
+  "coverage": [
+    "GT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "company",
+    "trust"
+  ],
+  "sector": [],
+  "code": "GT-NIT",
+  "confirmed": false,
+  "deprecated": false,
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "It is possible to search the list by NIT number.",
+    "publicDatabase": "https://portal.sat.gob.gt/portal/consulta-cui-nit/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": [
+      "ES"
+    ]
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Github proposal, World Bank Doing Business website, agency websites",
+    "lastUpdated": "2019-11-01"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gt/gt-nit.json
+++ b/lists/gt/gt-nit.json
@@ -5,26 +5,29 @@
   },
   "url": "https://portal.sat.gob.gt/portal/",
   "description": {
-    "en": "The Número de Identificación Tributaria (NIT) is a number assigned by the Superintendencia de Administración Tributaria in Guatemala to every tax payer, including both companies and individuals.\n\nCompanies must register with the Commercial Registry (Registro Mercantil) online at https://minegocio.gt/ to be incorporated and assigned an NIT number."
+    "en": "The Número de Identificación Tributaria (NIT) is a number assigned by the Superintendencia de Administración Tributaria in Guatemala to every tax payer, including both companies,  and individuals.\n\nCompanies must register with the Commercial Registry (Registro Mercantil) online at https://minegocio.gt/ to be incorporated and assigned an NIT number."
   },
   "coverage": [
     "GT"
   ],
   "subnationalCoverage": [],
   "structure": [
+    "charity",
     "company",
-    "trust"
+    "trust",
+    "government_agency",
+    "unincorporated_body"
   ],
   "sector": [],
   "code": "GT-NIT",
-  "confirmed": false,
+  "confirmed": true,
   "deprecated": false,
   "access": {
     "availableOnline": true,
     "onlineAccessDetails": "It is possible to search the list by NIT number.",
     "publicDatabase": "https://portal.sat.gob.gt/portal/consulta-cui-nit/",
     "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
+    "exampleIdentifiers": "7555605-7",
     "languages": [
       "ES"
     ]
@@ -37,7 +40,7 @@
   },
   "meta": {
     "source": "Github proposal, World Bank Doing Business website, agency websites",
-    "lastUpdated": "2019-11-01"
+    "lastUpdated": "2020-09-07"
   },
   "links": {
     "opencorporates": "",


### PR DESCRIPTION
A new list has been proposed with the code GT-NIT

**List title:** Guatemala Tax Identification Number

add draft GT-NIT list

 Preview the platform with this list at [http://org-id.guide/_preview_branch/GT-NIT](http://org-id.guide/_preview_branch/GT-NIT)  (visiting [http://org-id.guide/list/GT-NIT](http://org-id.guide/list/GT-NIT) when the preview is active or check the files changed options above.

Some further information is required before the list can be merged.