### PR TITLE
New  registry entry for 'Jersey Charity Register' (JE-JCR)

### DIFF
--- a/lists/je/je-jcr.json
+++ b/lists/je/je-jcr.json
@@ -5,14 +5,17 @@
   },
   "url": "https://charitycommissioner.je/",
   "description": {
-    "en": "The charity register contains key information about each registered charity and, with some limited exceptions, is fully open to public inspection so that people can if they wish understand more about the purposes, finances and public benefit delivery of the charities registered in Jersey."
+    "en": "The Jersey Charity Register register contains key information about each registered charity and, with some limited exceptions, is fully open to public inspection so that people can if they wish understand more about the purposes, finances and public benefit delivery of the charities registered in Jersey."
   },
   "coverage": [
     "JE"
   ],
   "subnationalCoverage": [],
   "structure": [
-    "charity"
+    "charity",
+    "company/limited_company",
+    "unincorporated_body",
+    "trust"
   ],
   "sector": [],
   "code": "JE-JCR",
@@ -23,7 +26,7 @@
     "availableOnline": true,
     "onlineAccessDetails": "",
     "publicDatabase": "https://portal.charitycommissioner.je/Public-Register/",
-    "guidanceOnLocatingIds": "Using the list URL go to the Public Register webpage. The identifier is the \"Jersey Charity Number\" column in the table. Further details are available by clicking through to the pages for each organization.",
+    "guidanceOnLocatingIds": "Using the website link go to the Public Register webpage. The identifier is the \"Jersey Charity Number\" column in the table. Further details are available by clicking through to the pages for each organization.",
     "exampleIdentifiers": "345, 69, 120",
     "languages": [
       "EN"
@@ -31,9 +34,17 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "",
-    "features": [],
-    "licenseStatus": "open_license",
+    "dataAccessDetails": "Although there is no means of accessing records as structured data, it is possible to browse the data fields across multiple web pages.",
+    "features": [
+      "directors_trustees_governors",
+      "registered_address",
+      "website",
+      "date_of_registration",
+      "registration_number",
+      "objectives_purpose",
+      "status"
+    ],
+    "licenseStatus": "no_license",
     "licenseDetails": ""
   },
   "meta": {

--- a/lists/je/je-jcr.json
+++ b/lists/je/je-jcr.json
@@ -49,7 +49,7 @@
   },
   "meta": {
     "source": "Original Research",
-    "lastUpdated": "2020-05-05"
+    "lastUpdated": "2020-05-19"
   },
   "links": {
     "opencorporates": "",

--- a/lists/je/je-jcr.json
+++ b/lists/je/je-jcr.json
@@ -1,0 +1,48 @@
+{
+  "name": {
+    "en": "Jersey Charity Register",
+    "local": ""
+  },
+  "url": "https://charitycommissioner.je/",
+  "description": {
+    "en": "The charity register contains key information about each registered charity and, with some limited exceptions, is fully open to public inspection so that people can if they wish understand more about the purposes, finances and public benefit delivery of the charities registered in Jersey."
+  },
+  "coverage": [
+    "JE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity"
+  ],
+  "sector": [],
+  "code": "JE-JCR",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "",
+    "publicDatabase": "https://portal.charitycommissioner.je/Public-Register/",
+    "guidanceOnLocatingIds": "Using the list URL go to the Public Register webpage. The identifier is the \"Jersey Charity Number\" column in the table. Further details are available by clicking through to the pages for each organization.",
+    "exampleIdentifiers": "345, 69, 120",
+    "languages": [
+      "EN"
+    ]
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "",
+    "features": [],
+    "licenseStatus": "open_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Original Research",
+    "lastUpdated": "2020-05-05"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}


### PR DESCRIPTION
A new list has been proposed with the code JE-JCR

**List title:** Jersey Charity Register

Added JE-JCR

 Preview the platform with this list at [http://org-id.guide/_preview_branch/JE-JCR](http://org-id.guide/_preview_branch/JE-JCR)  (visiting [http://org-id.guide/list/JE-JCR](http://org-id.guide/list/JE-JCR) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.