### PR TITLE
New  registry entry for 'Research Organization Registry' (XI-ROR)

### DIFF
--- a/lists/xi/xi-ror.json
+++ b/lists/xi/xi-ror.json
@@ -1,0 +1,67 @@
+{
+  "name": {
+    "en": "Research Organization Registry",
+    "local": ""
+  },
+  "url": "https://ror.community/",
+  "description": {
+    "en": "A community-led project to develop an open, sustainable, usable, and unique identifier for every research organization in the world."
+  },
+  "coverage": [
+    "XI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "charity",
+    "company",
+    "company/community_interest_company",
+    "company/limited_company",
+    "company/listed_company",
+    "company/mutual",
+    "company/partnership",
+    "government_agency",
+    "government_agency/local_government",
+    "government_agency/public_service",
+    "trust"
+  ],
+  "sector": [
+    "research"
+  ],
+  "code": "XI-ROR",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "primary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Using the URL, there is a search interface which allows you to find research organizations and identifiers",
+    "publicDatabase": "https://ror.org/",
+    "guidanceOnLocatingIds": "Using the URL, there is a search interface which allows you to find research organizations and identifiers",
+    "exampleIdentifiers": "05asf4e91, 01kj2bm70, 049e6bc10",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "api",
+      "bulk"
+    ],
+    "dataAccessDetails": "API: https://api.ror.org/organizations\nBulk Download: https://figshare.com/collections/ROR_Data/4596503",
+    "features": [
+      "industry_classifications",
+      "country_of_origin",
+      "status"
+    ],
+    "licenseStatus": "open_license",
+    "licenseDetails": "https://creativecommons.org/publicdomain/zero/1.0//"
+  },
+  "meta": {
+    "source": "Original Research",
+    "lastUpdated": "2020-05-05"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/xi/xi-ror.json
+++ b/lists/xi/xi-ror.json
@@ -5,7 +5,7 @@
   },
   "url": "https://ror.community/",
   "description": {
-    "en": "A community-led project to develop an open, sustainable, usable, and unique identifier for every research organization in the world."
+    "en": "The Research Organization Registry (ROR) is a community-led project to develop an open, sustainable, usable, and unique identifier for every research organization in the world. The definition ROR use for a \"research organization\" is \"any organization that conducts, produces, manages, or touches research\".\n\nThe list is seeded from GRID, but with a long-term intention to diverge from this."
   },
   "coverage": [
     "XI"
@@ -25,12 +25,13 @@
     "trust"
   ],
   "sector": [
-    "research"
+    "research",
+    "education"
   ],
   "code": "XI-ROR",
   "confirmed": true,
   "deprecated": false,
-  "listType": "primary",
+  "listType": "third_party",
   "access": {
     "availableOnline": true,
     "onlineAccessDetails": "Using the URL, there is a search interface which allows you to find research organizations and identifiers",
@@ -44,10 +45,13 @@
   "data": {
     "availability": [
       "api",
-      "bulk"
+      "bulk",
+      "json"
     ],
     "dataAccessDetails": "API: https://api.ror.org/organizations\nBulk Download: https://figshare.com/collections/ROR_Data/4596503",
     "features": [
+      "akas",
+      "website",
       "industry_classifications",
       "country_of_origin",
       "status"


### PR DESCRIPTION
A new list has been proposed with the code XI-ROR

**List title:** Research Organization Registry

Added XI-ROR

 Preview the platform with this list at [http://org-id.guide/_preview_branch/XI-ROR](http://org-id.guide/_preview_branch/XI-ROR)  (visiting [http://org-id.guide/list/XI-ROR](http://org-id.guide/list/XI-ROR) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.