### PR TITLE
Add COA files for countries from gov-id-finder.codeforiati.org

### DIFF
--- a/lists/ae/ae-coa.json
+++ b/lists/ae/ae-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/AE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "AE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United Arab Emirates (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United Arab Emirates (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AE/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ae/ae-coa.json
+++ b/lists/ae/ae-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "United Arab Emirates (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United Arab Emirates (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ag/ag-coa.json
+++ b/lists/ag/ag-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/AG/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "AG"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Antigua and Barbuda.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Antigua and Barbuda.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AG/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ag/ag-coa.json
+++ b/lists/ag/ag-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Antigua and Barbuda Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Antigua and Barbuda.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/al/al-coa.json
+++ b/lists/al/al-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/AL/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "AL"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Albania.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Albania.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AL/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/al/al-coa.json
+++ b/lists/al/al-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Albania Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Albania.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/am/am-coa.json
+++ b/lists/am/am-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/AM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "AM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AM/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "101001, 101002",

--- a/lists/am/am-coa.json
+++ b/lists/am/am-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Armenia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101001, 101002",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/AM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ao/ao-coa.json
+++ b/lists/ao/ao-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/AO/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "AO"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Angola.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Angola.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AO/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ao/ao-coa.json
+++ b/lists/ao/ao-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Angola Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Angola.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ar/ar-coa.json
+++ b/lists/ar/ar-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Argentina Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Argentina.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ar/ar-coa.json
+++ b/lists/ar/ar-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/AR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "AR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Argentina.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Argentina.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/at/at-coa.json
+++ b/lists/at/at-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Austria Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Austria.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/at/at-coa.json
+++ b/lists/at/at-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/AT/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "AT"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Austria.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Austria.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AT/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/au/au-coa.json
+++ b/lists/au/au-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/AU/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "AU"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Australia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Australia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AU/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/au/au-coa.json
+++ b/lists/au/au-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Australia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Australia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/aw/aw-coa.json
+++ b/lists/aw/aw-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Aruba Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Aruba.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AW/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/aw/aw-coa.json
+++ b/lists/aw/aw-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/AW/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "AW"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Aruba.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Aruba.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AW/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/az/az-coa.json
+++ b/lists/az/az-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/AZ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "AZ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Azerbaijan.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Azerbaijan.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AZ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/az/az-coa.json
+++ b/lists/az/az-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Azerbaijan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Azerbaijan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ba/ba-coa.json
+++ b/lists/ba/ba-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bosnia and Herzegovina Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bosnia and Herzegovina.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ba/ba-coa.json
+++ b/lists/ba/ba-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BA/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BA"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bosnia and Herzegovina.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bosnia and Herzegovina.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BA/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bb/bb-coa.json
+++ b/lists/bb/bb-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BB/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BB"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Barbados.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Barbados.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BB/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bb/bb-coa.json
+++ b/lists/bb/bb-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Barbados Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BB/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BB"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BB-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Barbados.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BB/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bd/bd-coa.json
+++ b/lists/bd/bd-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Bangladesh Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BD/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101, 102",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BD/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bd/bd-coa.json
+++ b/lists/bd/bd-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BD/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BD"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BD/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "101, 102",

--- a/lists/be/be-coa.json
+++ b/lists/be/be-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Belgium Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belgium.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/be/be-coa.json
+++ b/lists/be/be-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belgium.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belgium.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BE/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bf/bf-coa.json
+++ b/lists/bf/bf-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BF/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BF"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BF/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "14, 1",

--- a/lists/bf/bf-coa.json
+++ b/lists/bf/bf-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Burkina Faso Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BF/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BF"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BF-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BF/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "14, 1",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BF/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bg/bg-coa.json
+++ b/lists/bg/bg-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bulgaria Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bulgaria.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bg/bg-coa.json
+++ b/lists/bg/bg-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BG/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BG"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bulgaria.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bulgaria.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BG/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bh/bh-coa.json
+++ b/lists/bh/bh-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bahrain Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bahrain.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bh/bh-coa.json
+++ b/lists/bh/bh-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BH/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BH"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bahrain.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bahrain.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BH/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bi/bi-coa.json
+++ b/lists/bi/bi-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BI/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BI"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BI/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "01, 02",

--- a/lists/bi/bi-coa.json
+++ b/lists/bi/bi-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Burundi Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BI/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BI/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bj/bj-coa.json
+++ b/lists/bj/bj-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BJ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BJ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Benin.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Benin.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BJ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bj/bj-coa.json
+++ b/lists/bj/bj-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Benin Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BJ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BJ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BJ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Benin.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BJ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bm/bm-coa.json
+++ b/lists/bm/bm-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bermuda.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bermuda.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BM/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bm/bm-coa.json
+++ b/lists/bm/bm-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bermuda Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bermuda.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bn/bn-coa.json
+++ b/lists/bn/bn-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BN/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BN"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Brunei Darussalam.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Brunei Darussalam.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BN/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bn/bn-coa.json
+++ b/lists/bn/bn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Brunei Darussalam Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Brunei Darussalam.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bo/bo-coa.json
+++ b/lists/bo/bo-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Bolivia (Plurinational State of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BO/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "0006, 0010",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BO/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bo/bo-coa.json
+++ b/lists/bo/bo-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BO/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BO"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BO/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "0006, 0010",

--- a/lists/br/br-coa.json
+++ b/lists/br/br-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Brazil.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Brazil.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/br/br-coa.json
+++ b/lists/br/br-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Brazil Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Brazil.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bs/bs-coa.json
+++ b/lists/bs/bs-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bahamas (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bahamas (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bs/bs-coa.json
+++ b/lists/bs/bs-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BS/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BS"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bahamas (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bahamas (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BS/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bt/bt-coa.json
+++ b/lists/bt/bt-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Bhutan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BT/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101.01, 102.01",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BT/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bt/bt-coa.json
+++ b/lists/bt/bt-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BT/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BT"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BT/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "101.01, 102.01",

--- a/lists/bw/bw-coa.json
+++ b/lists/bw/bw-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Botswana Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Botswana.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BW/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bw/bw-coa.json
+++ b/lists/bw/bw-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BW/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BW"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Botswana.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Botswana.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BW/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/by/by-coa.json
+++ b/lists/by/by-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Belarus Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belarus.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/by/by-coa.json
+++ b/lists/by/by-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BY/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BY"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belarus.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belarus.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BY/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bz/bz-coa.json
+++ b/lists/bz/bz-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/BZ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "BZ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belize.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belize.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BZ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bz/bz-coa.json
+++ b/lists/bz/bz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Belize Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belize.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ca/ca-coa.json
+++ b/lists/ca/ca-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CA/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CA"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Canada.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Canada.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CA/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ca/ca-coa.json
+++ b/lists/ca/ca-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Canada Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Canada.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cd/cd-coa.json
+++ b/lists/cd/cd-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Congo (the Democratic Republic of the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CD/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "10, 11",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/CD/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cd/cd-coa.json
+++ b/lists/cd/cd-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CD/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CD"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CD/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "10, 11",

--- a/lists/cf/cf-coa.json
+++ b/lists/cf/cf-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Central African Republic (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CF/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CF"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CF-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CF/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/CF/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cf/cf-coa.json
+++ b/lists/cf/cf-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CF/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CF"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CF/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "01, 02 ",

--- a/lists/cg/cg-coa.json
+++ b/lists/cg/cg-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CG/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CG"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Congo (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Congo (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CG/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/cg/cg-coa.json
+++ b/lists/cg/cg-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Congo (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Congo (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ch/ch-coa.json
+++ b/lists/ch/ch-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CH/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CH"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Switzerland.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Switzerland.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CH/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ch/ch-coa.json
+++ b/lists/ch/ch-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Switzerland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Switzerland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ci/ci-coa.json
+++ b/lists/ci/ci-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "C\u00f4te d'Ivoire Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CI/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/CI/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ci/ci-coa.json
+++ b/lists/ci/ci-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CI/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CI"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CI/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "01, 02 ",

--- a/lists/cl/cl-coa.json
+++ b/lists/cl/cl-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CL/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CL"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Chile.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Chile.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CL/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/cl/cl-coa.json
+++ b/lists/cl/cl-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Chile Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Chile.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cm/cm-coa.json
+++ b/lists/cm/cm-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CM/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "01 , 02",

--- a/lists/cm/cm-coa.json
+++ b/lists/cm/cm-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Cameroon Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01 , 02",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/CM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cn/cn-coa.json
+++ b/lists/cn/cn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "China Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for China.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cn/cn-coa.json
+++ b/lists/cn/cn-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CN/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CN"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for China.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for China.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CN/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/co/co-coa.json
+++ b/lists/co/co-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CO/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CO"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Colombia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Colombia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CO/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/co/co-coa.json
+++ b/lists/co/co-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Colombia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Colombia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cr/cr-coa.json
+++ b/lists/cr/cr-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Costa Rica.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Costa Rica.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/cr/cr-coa.json
+++ b/lists/cr/cr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Costa Rica Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Costa Rica.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cu/cu-coa.json
+++ b/lists/cu/cu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Cuba Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cuba.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cu/cu-coa.json
+++ b/lists/cu/cu-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CU/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CU"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cuba.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cuba.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CU/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/cv/cv-coa.json
+++ b/lists/cv/cv-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CV/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CV"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cabo Verde.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cabo Verde.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CV/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/cv/cv-coa.json
+++ b/lists/cv/cv-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Cabo Verde Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CV/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CV"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CV-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cabo Verde.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CV/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cy/cy-coa.json
+++ b/lists/cy/cy-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CY/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CY"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cyprus.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cyprus.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CY/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/cy/cy-coa.json
+++ b/lists/cy/cy-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Cyprus Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cyprus.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cz/cz-coa.json
+++ b/lists/cz/cz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Czechia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Czechia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cz/cz-coa.json
+++ b/lists/cz/cz-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/CZ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "CZ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Czechia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Czechia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CZ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/de/de-coa.json
+++ b/lists/de/de-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Germany Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Germany.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/de/de-coa.json
+++ b/lists/de/de-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/DE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "DE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Germany.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Germany.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DE/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/dj/dj-coa.json
+++ b/lists/dj/dj-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/DJ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "DJ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Djibouti.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Djibouti.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DJ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/dj/dj-coa.json
+++ b/lists/dj/dj-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Djibouti Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DJ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DJ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DJ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Djibouti.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DJ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/dk/dk-coa.json
+++ b/lists/dk/dk-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/DK/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "DK"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Denmark.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Denmark.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DK/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/dk/dk-coa.json
+++ b/lists/dk/dk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Denmark Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Denmark.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/dm/dm-coa.json
+++ b/lists/dm/dm-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Dominica Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Dominica.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/dm/dm-coa.json
+++ b/lists/dm/dm-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/DM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "DM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Dominica.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Dominica.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DM/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/do/do-coa.json
+++ b/lists/do/do-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/DO/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "DO"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Dominican Republic (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Dominican Republic (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DO/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/do/do-coa.json
+++ b/lists/do/do-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Dominican Republic (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Dominican Republic (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/dz/dz-coa.json
+++ b/lists/dz/dz-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/DZ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "DZ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Algeria.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Algeria.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DZ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/dz/dz-coa.json
+++ b/lists/dz/dz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Algeria Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Algeria.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ec/ec-coa.json
+++ b/lists/ec/ec-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/EC/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "EC"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ecuador.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ecuador.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/EC/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ec/ec-coa.json
+++ b/lists/ec/ec-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Ecuador Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/EC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "EC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "EC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ecuador.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/EC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ee/ee-coa.json
+++ b/lists/ee/ee-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Estonia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/EE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "EE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "EE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Estonia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/EE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ee/ee-coa.json
+++ b/lists/ee/ee-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/EE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "EE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Estonia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Estonia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/EE/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/eg/eg-coa.json
+++ b/lists/eg/eg-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Egypt Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/EG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "EG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "EG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Egypt.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/EG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/eg/eg-coa.json
+++ b/lists/eg/eg-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/EG/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "EG"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Egypt.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Egypt.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/EG/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/er/er-coa.json
+++ b/lists/er/er-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Eritrea Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ER/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ER"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ER-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Eritrea.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ER/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/er/er-coa.json
+++ b/lists/er/er-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/ER/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "ER"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Eritrea.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Eritrea.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ER/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/es/es-coa.json
+++ b/lists/es/es-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Spain Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ES/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ES"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ES-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Spain.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ES/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/es/es-coa.json
+++ b/lists/es/es-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/ES/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "ES"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Spain.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Spain.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ES/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/et/et-coa.json
+++ b/lists/et/et-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/ET/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "ET"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ET/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "100, 110",

--- a/lists/et/et-coa.json
+++ b/lists/et/et-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Ethiopia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ET/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ET"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ET-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ET/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "100, 110",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/ET/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/fi/fi-coa.json
+++ b/lists/fi/fi-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/FI/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "FI"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Finland.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Finland.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FI/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/fi/fi-coa.json
+++ b/lists/fi/fi-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Finland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/FI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "FI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "FI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Finland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FI/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/fj/fj-coa.json
+++ b/lists/fj/fj-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Fiji Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/FJ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "FJ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "FJ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Fiji.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FJ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/fj/fj-coa.json
+++ b/lists/fj/fj-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/FJ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "FJ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Fiji.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Fiji.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FJ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/fm/fm-coa.json
+++ b/lists/fm/fm-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/FM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "FM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Micronesia (Federated States of).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Micronesia (Federated States of).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FM/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/fm/fm-coa.json
+++ b/lists/fm/fm-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Micronesia (Federated States of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/FM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "FM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "FM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Micronesia (Federated States of).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/fr/fr-coa.json
+++ b/lists/fr/fr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "France Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/FR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "FR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "FR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for France.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/fr/fr-coa.json
+++ b/lists/fr/fr-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/FR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "FR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for France.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for France.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ga/ga-coa.json
+++ b/lists/ga/ga-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GA/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GA"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Gabon.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Gabon.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GA/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ga/ga-coa.json
+++ b/lists/ga/ga-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Gabon Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Gabon.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gb/gb-coa.json
+++ b/lists/gb/gb-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GB/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GB"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United Kingdom of Great Britain and Northern Ireland (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United Kingdom of Great Britain and Northern Ireland (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GB/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/gb/gb-coa.json
+++ b/lists/gb/gb-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "United Kingdom of Great Britain and Northern Ireland (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GB/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GB"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GB-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United Kingdom of Great Britain and Northern Ireland (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GB/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gd/gd-coa.json
+++ b/lists/gd/gd-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GD/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GD"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Grenada.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Grenada.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GD/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/gd/gd-coa.json
+++ b/lists/gd/gd-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Grenada Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Grenada.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GD/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ge/ge-coa.json
+++ b/lists/ge/ge-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Georgia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Georgia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ge/ge-coa.json
+++ b/lists/ge/ge-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Georgia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Georgia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GE/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/gg/gg-coa.json
+++ b/lists/gg/gg-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Guernsey Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guernsey.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gg/gg-coa.json
+++ b/lists/gg/gg-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GG/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GG"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guernsey.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guernsey.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GG/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/gh/gh-coa.json
+++ b/lists/gh/gh-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Ghana Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GH/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/GH/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gh/gh-coa.json
+++ b/lists/gh/gh-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GH/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GH"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GH/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1, 2",

--- a/lists/gi/gi-coa.json
+++ b/lists/gi/gi-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GI/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GI"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Gibraltar.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Gibraltar.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GI/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/gi/gi-coa.json
+++ b/lists/gi/gi-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Gibraltar Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Gibraltar.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GI/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gl/gl-coa.json
+++ b/lists/gl/gl-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GL/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GL"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Greenland.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Greenland.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GL/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/gl/gl-coa.json
+++ b/lists/gl/gl-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Greenland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Greenland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gm/gm-coa.json
+++ b/lists/gm/gm-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Gambia (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01 , 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/GM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gm/gm-coa.json
+++ b/lists/gm/gm-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GM/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "01 , 02 ",

--- a/lists/gn/gn-coa.json
+++ b/lists/gn/gn-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Guinea Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GN/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "04, 06",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/GN/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gn/gn-coa.json
+++ b/lists/gn/gn-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GN/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GN"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GN/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "04, 06",

--- a/lists/gq/gq-coa.json
+++ b/lists/gq/gq-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GQ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GQ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Equatorial Guinea.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Equatorial Guinea.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GQ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/gq/gq-coa.json
+++ b/lists/gq/gq-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Equatorial Guinea Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GQ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GQ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GQ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Equatorial Guinea.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GQ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gr/gr-coa.json
+++ b/lists/gr/gr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Greece Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Greece.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gr/gr-coa.json
+++ b/lists/gr/gr-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Greece.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Greece.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/gt/gt-coa.json
+++ b/lists/gt/gt-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Guatemala Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guatemala.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gt/gt-coa.json
+++ b/lists/gt/gt-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GT/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GT"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guatemala.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guatemala.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GT/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/gw/gw-coa.json
+++ b/lists/gw/gw-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GW/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GW"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GW/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1, 6",

--- a/lists/gw/gw-coa.json
+++ b/lists/gw/gw-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Guinea-Bissau Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GW/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 6",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/GW/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gy/gy-coa.json
+++ b/lists/gy/gy-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Guyana Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guyana.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gy/gy-coa.json
+++ b/lists/gy/gy-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/GY/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "GY"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guyana.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guyana.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GY/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/hk/hk-coa.json
+++ b/lists/hk/hk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Hong Kong Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/HK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "HK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "HK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Hong Kong.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/hk/hk-coa.json
+++ b/lists/hk/hk-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/HK/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "HK"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Hong Kong.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Hong Kong.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HK/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/hn/hn-coa.json
+++ b/lists/hn/hn-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/HN/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "HN"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Honduras.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Honduras.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HN/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/hn/hn-coa.json
+++ b/lists/hn/hn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Honduras Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/HN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "HN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "HN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Honduras.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/hr/hr-coa.json
+++ b/lists/hr/hr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Croatia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/HR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "HR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "HR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Croatia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/hr/hr-coa.json
+++ b/lists/hr/hr-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/HR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "HR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Croatia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Croatia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ht/ht-coa.json
+++ b/lists/ht/ht-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Haiti Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/HT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "HT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "HT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HT/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1111, 1112",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/HT/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ht/ht-coa.json
+++ b/lists/ht/ht-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/HT/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "HT"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HT/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1111, 1112",

--- a/lists/hu/hu-coa.json
+++ b/lists/hu/hu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Hungary Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/HU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "HU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "HU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Hungary.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/hu/hu-coa.json
+++ b/lists/hu/hu-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/HU/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "HU"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Hungary.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Hungary.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HU/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/id/id-coa.json
+++ b/lists/id/id-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Indonesia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ID/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ID"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ID-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ID/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/ID/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/id/id-coa.json
+++ b/lists/id/id-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/ID/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "ID"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ID/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1, 2",

--- a/lists/ie/ie-coa.json
+++ b/lists/ie/ie-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/IE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "IE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ireland.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ireland.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IE/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ie/ie-coa.json
+++ b/lists/ie/ie-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Ireland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ireland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/il/il-coa.json
+++ b/lists/il/il-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Israel Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Israel.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/il/il-coa.json
+++ b/lists/il/il-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/IL/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "IL"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Israel.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Israel.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IL/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/im/im-coa.json
+++ b/lists/im/im-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Isle of Man Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Isle of Man.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/im/im-coa.json
+++ b/lists/im/im-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/IM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "IM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Isle of Man.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Isle of Man.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IM/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/in/in-coa.json
+++ b/lists/in/in-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/IN/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "IN"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for India.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for India.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IN/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/in/in-coa.json
+++ b/lists/in/in-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "India Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for India.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/iq/iq-coa.json
+++ b/lists/iq/iq-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/IQ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "IQ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iraq.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iraq.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IQ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/iq/iq-coa.json
+++ b/lists/iq/iq-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Iraq Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IQ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IQ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IQ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iraq.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IQ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ir/ir-coa.json
+++ b/lists/ir/ir-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Iran (Islamic Republic of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iran (Islamic Republic of).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ir/ir-coa.json
+++ b/lists/ir/ir-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/IR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "IR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iran (Islamic Republic of).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iran (Islamic Republic of).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/is/is-coa.json
+++ b/lists/is/is-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/IS/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "IS"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iceland.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iceland.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IS/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/is/is-coa.json
+++ b/lists/is/is-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Iceland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iceland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/it/it-coa.json
+++ b/lists/it/it-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Italy Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Italy.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/it/it-coa.json
+++ b/lists/it/it-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/IT/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "IT"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Italy.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Italy.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IT/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/je/je-coa.json
+++ b/lists/je/je-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/JE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "JE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Jersey.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Jersey.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JE/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/je/je-coa.json
+++ b/lists/je/je-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Jersey Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/JE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "JE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "JE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Jersey.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/jm/jm-coa.json
+++ b/lists/jm/jm-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Jamaica Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/JM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "JM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "JM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1000, 2000",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/JM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/jm/jm-coa.json
+++ b/lists/jm/jm-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/JM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "JM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JM/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1000, 2000",

--- a/lists/jo/jo-coa.json
+++ b/lists/jo/jo-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Jordan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/JO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "JO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "JO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JO/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "0101, 0201",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/JO/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/jo/jo-coa.json
+++ b/lists/jo/jo-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/JO/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "JO"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JO/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "0101, 0201",

--- a/lists/jp/jp-coa.json
+++ b/lists/jp/jp-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/JP/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "JP"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Japan.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Japan.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JP/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/jp/jp-coa.json
+++ b/lists/jp/jp-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Japan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/JP/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "JP"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "JP-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Japan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JP/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ke/ke-coa.json
+++ b/lists/ke/ke-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Kenya Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KE/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "110, 119",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KE/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ke/ke-coa.json
+++ b/lists/ke/ke-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/KE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "KE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KE/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "110, 119",

--- a/lists/kg/kg-coa.json
+++ b/lists/kg/kg-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Kyrgyzstan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KG/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "11, 11",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KG/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kg/kg-coa.json
+++ b/lists/kg/kg-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/KG/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "KG"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KG/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "11, 11",

--- a/lists/kh/kh-coa.json
+++ b/lists/kh/kh-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Cambodia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KH/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KH/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kh/kh-coa.json
+++ b/lists/kh/kh-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/KH/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "KH"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KH/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1, 2",

--- a/lists/ki/ki-coa.json
+++ b/lists/ki/ki-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Kiribati Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KI/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 11",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KI/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ki/ki-coa.json
+++ b/lists/ki/ki-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/KI/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "KI"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KI/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "01, 11",

--- a/lists/km/km-coa.json
+++ b/lists/km/km-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/KM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "KM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Comoros (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Comoros (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KM/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/km/km-coa.json
+++ b/lists/km/km-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Comoros (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Comoros (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kn/kn-coa.json
+++ b/lists/kn/kn-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Saint Kitts and Nevis Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KN/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KN/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kn/kn-coa.json
+++ b/lists/kn/kn-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/KN/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "KN"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KN/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "01, 02 ",

--- a/lists/kr/kr-coa.json
+++ b/lists/kr/kr-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/KR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "KR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Korea (the Republic of).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Korea (the Republic of).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/kr/kr-coa.json
+++ b/lists/kr/kr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Korea (the Republic of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Korea (the Republic of).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kw/kw-coa.json
+++ b/lists/kw/kw-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Kuwait Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kuwait.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KW/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kw/kw-coa.json
+++ b/lists/kw/kw-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/KW/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "KW"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kuwait.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kuwait.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KW/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/kz/kz-coa.json
+++ b/lists/kz/kz-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/KZ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "KZ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kazakhstan.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kazakhstan.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KZ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/kz/kz-coa.json
+++ b/lists/kz/kz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Kazakhstan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kazakhstan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/la/la-coa.json
+++ b/lists/la/la-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Lao People's Democratic Republic (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LA/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/LA/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/la/la-coa.json
+++ b/lists/la/la-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/LA/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "LA"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LA/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1, 2",

--- a/lists/lb/lb-coa.json
+++ b/lists/lb/lb-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Lebanon Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LB/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LB"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LB-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Lebanon.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LB/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lb/lb-coa.json
+++ b/lists/lb/lb-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/LB/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "LB"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Lebanon.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Lebanon.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LB/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/lc/lc-coa.json
+++ b/lists/lc/lc-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Saint Lucia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Lucia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lc/lc-coa.json
+++ b/lists/lc/lc-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/LC/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "LC"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Lucia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Lucia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LC/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/li/li-coa.json
+++ b/lists/li/li-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Liechtenstein Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Liechtenstein.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LI/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/li/li-coa.json
+++ b/lists/li/li-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/LI/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "LI"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Liechtenstein.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Liechtenstein.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LI/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/lk/lk-coa.json
+++ b/lists/lk/lk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Sri Lanka Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sri Lanka.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lk/lk-coa.json
+++ b/lists/lk/lk-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/LK/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "LK"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sri Lanka.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sri Lanka.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LK/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/lr/lr-coa.json
+++ b/lists/lr/lr-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Liberia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LR/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101, 104",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/LR/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lr/lr-coa.json
+++ b/lists/lr/lr-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/LR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "LR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LR/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "101, 104",

--- a/lists/ls/ls-coa.json
+++ b/lists/ls/ls-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Lesotho Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LS/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "001, 002",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/LS/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ls/ls-coa.json
+++ b/lists/ls/ls-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/LS/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "LS"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LS/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "001, 002",

--- a/lists/lt/lt-coa.json
+++ b/lists/lt/lt-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Lithuania Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Lithuania.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lt/lt-coa.json
+++ b/lists/lt/lt-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/LT/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "LT"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Lithuania.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Lithuania.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LT/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/lu/lu-coa.json
+++ b/lists/lu/lu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Luxembourg Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Luxembourg.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lu/lu-coa.json
+++ b/lists/lu/lu-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/LU/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "LU"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Luxembourg.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Luxembourg.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LU/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/lv/lv-coa.json
+++ b/lists/lv/lv-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Latvia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LV/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LV"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LV-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Latvia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LV/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lv/lv-coa.json
+++ b/lists/lv/lv-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/LV/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "LV"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Latvia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Latvia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LV/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ma/ma-coa.json
+++ b/lists/ma/ma-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MA/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MA"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Morocco.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Morocco.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MA/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ma/ma-coa.json
+++ b/lists/ma/ma-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Morocco Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Morocco.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mc/mc-coa.json
+++ b/lists/mc/mc-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MC/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MC"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Monaco.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Monaco.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MC/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/mc/mc-coa.json
+++ b/lists/mc/mc-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Monaco Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Monaco.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/md/md-coa.json
+++ b/lists/md/md-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MD/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MD"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Moldova (the Republic of).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Moldova (the Republic of).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MD/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/md/md-coa.json
+++ b/lists/md/md-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Moldova (the Republic of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Moldova (the Republic of).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MD/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/me/me-coa.json
+++ b/lists/me/me-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/ME/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "ME"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Montenegro.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Montenegro.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ME/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/me/me-coa.json
+++ b/lists/me/me-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Montenegro Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ME/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ME"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ME-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Montenegro.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ME/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mh/mh-coa.json
+++ b/lists/mh/mh-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Marshall Islands (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Marshall Islands (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mh/mh-coa.json
+++ b/lists/mh/mh-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MH/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MH"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Marshall Islands (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Marshall Islands (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MH/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/mk/mk-coa.json
+++ b/lists/mk/mk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "North Macedonia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for North Macedonia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mk/mk-coa.json
+++ b/lists/mk/mk-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MK/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MK"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for North Macedonia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for North Macedonia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MK/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ml/ml-coa.json
+++ b/lists/ml/ml-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Mali Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ML/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ML"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ML-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ML/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "110, 110",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/ML/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ml/ml-coa.json
+++ b/lists/ml/ml-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/ML/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "ML"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ML/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "110, 110",

--- a/lists/mm/mm-coa.json
+++ b/lists/mm/mm-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MM/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1, 2",

--- a/lists/mm/mm-coa.json
+++ b/lists/mm/mm-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Myanmar Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/MM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mn/mn-coa.json
+++ b/lists/mn/mn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Mongolia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mongolia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mn/mn-coa.json
+++ b/lists/mn/mn-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MN/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MN"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mongolia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mongolia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MN/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/mr/mr-coa.json
+++ b/lists/mr/mr-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MR/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "12, 17",

--- a/lists/mr/mr-coa.json
+++ b/lists/mr/mr-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Mauritania Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MR/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "12, 17",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/MR/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mt/mt-coa.json
+++ b/lists/mt/mt-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MT/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MT"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Malta.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Malta.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MT/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/mt/mt-coa.json
+++ b/lists/mt/mt-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Malta Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Malta.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mu/mu-coa.json
+++ b/lists/mu/mu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Mauritius Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mauritius.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mu/mu-coa.json
+++ b/lists/mu/mu-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MU/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MU"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mauritius.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mauritius.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MU/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/mv/mv-coa.json
+++ b/lists/mv/mv-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Maldives Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MV/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MV"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MV-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Maldives.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MV/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mv/mv-coa.json
+++ b/lists/mv/mv-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MV/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MV"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Maldives.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Maldives.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MV/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/mw/mw-coa.json
+++ b/lists/mw/mw-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Malawi Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MW/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "010 , 020 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/MW/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mw/mw-coa.json
+++ b/lists/mw/mw-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MW/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MW"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MW/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "010 , 020 ",

--- a/lists/mx/mx-coa.json
+++ b/lists/mx/mx-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Mexico Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MX/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MX"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MX-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mexico.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MX/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mx/mx-coa.json
+++ b/lists/mx/mx-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MX/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MX"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mexico.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mexico.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MX/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/my/my-coa.json
+++ b/lists/my/my-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MY/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MY"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Malaysia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Malaysia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MY/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/my/my-coa.json
+++ b/lists/my/my-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Malaysia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Malaysia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mz/mz-coa.json
+++ b/lists/mz/mz-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Mozambique Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MZ/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01A000141, 01A000541",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/MZ/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mz/mz-coa.json
+++ b/lists/mz/mz-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/MZ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "MZ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MZ/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "01A000141, 01A000541",

--- a/lists/na/na-coa.json
+++ b/lists/na/na-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/NA/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "NA"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Namibia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Namibia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NA/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/na/na-coa.json
+++ b/lists/na/na-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Namibia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Namibia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ne/ne-coa.json
+++ b/lists/ne/ne-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/NE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "NE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NE/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "47, 0",

--- a/lists/ne/ne-coa.json
+++ b/lists/ne/ne-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Niger (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NE/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "47, 0",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/NE/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ng/ng-coa.json
+++ b/lists/ng/ng-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Nigeria Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Nigeria.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ng/ng-coa.json
+++ b/lists/ng/ng-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/NG/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "NG"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Nigeria.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Nigeria.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NG/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ni/ni-coa.json
+++ b/lists/ni/ni-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Nicaragua Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NI/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/NI/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ni/ni-coa.json
+++ b/lists/ni/ni-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/NI/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "NI"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NI/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1, 2",

--- a/lists/nl/nl-coa.json
+++ b/lists/nl/nl-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Netherlands (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Netherlands (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/nl/nl-coa.json
+++ b/lists/nl/nl-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/NL/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "NL"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Netherlands (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Netherlands (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NL/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/no/no-coa.json
+++ b/lists/no/no-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Norway Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Norway.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/no/no-coa.json
+++ b/lists/no/no-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/NO/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "NO"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Norway.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Norway.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NO/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/np/np-coa.json
+++ b/lists/np/np-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Nepal Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NP/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NP"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NP-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NP/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101, 102",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/NP/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/np/np-coa.json
+++ b/lists/np/np-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/NP/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "NP"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NP/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "101, 102",

--- a/lists/nz/nz-coa.json
+++ b/lists/nz/nz-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/NZ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "NZ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for New Zealand.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for New Zealand.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NZ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/nz/nz-coa.json
+++ b/lists/nz/nz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "New Zealand Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for New Zealand.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/om/om-coa.json
+++ b/lists/om/om-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/OM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "OM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Oman.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Oman.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/OM/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/om/om-coa.json
+++ b/lists/om/om-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Oman Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/OM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "OM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "OM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Oman.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/OM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pa/pa-coa.json
+++ b/lists/pa/pa-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/PA/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "PA"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Panama.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Panama.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PA/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/pa/pa-coa.json
+++ b/lists/pa/pa-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Panama Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Panama.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pe/pe-coa.json
+++ b/lists/pe/pe-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Peru Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Peru.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pe/pe-coa.json
+++ b/lists/pe/pe-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/PE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "PE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Peru.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Peru.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PE/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/pg/pg-coa.json
+++ b/lists/pg/pg-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/PG/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "PG"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PG/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "201, 202",

--- a/lists/pg/pg-coa.json
+++ b/lists/pg/pg-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Papua New Guinea Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PG/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "201, 202",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/PG/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ph/ph-coa.json
+++ b/lists/ph/ph-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Philippines (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Philippines (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ph/ph-coa.json
+++ b/lists/ph/ph-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/PH/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "PH"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Philippines (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Philippines (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PH/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/pk/pk-coa.json
+++ b/lists/pk/pk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Pakistan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Pakistan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pk/pk-coa.json
+++ b/lists/pk/pk-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/PK/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "PK"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Pakistan.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Pakistan.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PK/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/pl/pl-coa.json
+++ b/lists/pl/pl-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/PL/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "PL"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Poland.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Poland.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PL/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/pl/pl-coa.json
+++ b/lists/pl/pl-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Poland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Poland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pr/pr-coa.json
+++ b/lists/pr/pr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Puerto Rico Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Puerto Rico.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pr/pr-coa.json
+++ b/lists/pr/pr-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/PR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "PR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Puerto Rico.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Puerto Rico.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ps/ps-coa.json
+++ b/lists/ps/ps-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Palestine, State of Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Palestine, State of.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ps/ps-coa.json
+++ b/lists/ps/ps-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/PS/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "PS"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Palestine, State of.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Palestine, State of.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PS/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/pt/pt-coa.json
+++ b/lists/pt/pt-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/PT/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "PT"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Portugal.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Portugal.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PT/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/pt/pt-coa.json
+++ b/lists/pt/pt-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Portugal Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Portugal.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pw/pw-coa.json
+++ b/lists/pw/pw-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/PW/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "PW"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PW/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1, 2",

--- a/lists/pw/pw-coa.json
+++ b/lists/pw/pw-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Palau Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PW/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/PW/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/py/py-coa.json
+++ b/lists/py/py-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Paraguay Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Paraguay.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/py/py-coa.json
+++ b/lists/py/py-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/PY/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "PY"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Paraguay.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Paraguay.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PY/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/qa/qa-coa.json
+++ b/lists/qa/qa-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Qatar Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/QA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "QA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "QA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Qatar.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/QA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/qa/qa-coa.json
+++ b/lists/qa/qa-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/QA/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "QA"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Qatar.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Qatar.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/QA/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ro/ro-coa.json
+++ b/lists/ro/ro-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/RO/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "RO"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Romania.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Romania.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RO/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ro/ro-coa.json
+++ b/lists/ro/ro-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Romania Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/RO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "RO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "RO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Romania.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/rs/rs-coa.json
+++ b/lists/rs/rs-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Serbia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/RS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "RS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "RS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Serbia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/rs/rs-coa.json
+++ b/lists/rs/rs-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/RS/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "RS"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Serbia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Serbia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RS/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ru/ru-coa.json
+++ b/lists/ru/ru-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/RU/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "RU"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Russian Federation (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Russian Federation (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RU/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ru/ru-coa.json
+++ b/lists/ru/ru-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Russian Federation (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/RU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "RU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "RU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Russian Federation (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/rw/rw-coa.json
+++ b/lists/rw/rw-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/RW/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "RW"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RW/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "01, 02 ",

--- a/lists/rw/rw-coa.json
+++ b/lists/rw/rw-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Rwanda Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/RW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "RW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "RW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RW/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/RW/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sa/sa-coa.json
+++ b/lists/sa/sa-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SA/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SA"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saudi Arabia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saudi Arabia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SA/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/sa/sa-coa.json
+++ b/lists/sa/sa-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Saudi Arabia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saudi Arabia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sb/sb-coa.json
+++ b/lists/sb/sb-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SB/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SB"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SB/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "470, 474",

--- a/lists/sb/sb-coa.json
+++ b/lists/sb/sb-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Solomon Islands Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SB/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SB"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SB-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SB/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "470, 474",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/SB/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sc/sc-coa.json
+++ b/lists/sc/sc-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SC/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SC"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Seychelles.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Seychelles.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SC/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/sc/sc-coa.json
+++ b/lists/sc/sc-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Seychelles Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Seychelles.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sd/sd-coa.json
+++ b/lists/sd/sd-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SD/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SD"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sudan (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sudan (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SD/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/sd/sd-coa.json
+++ b/lists/sd/sd-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Sudan (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sudan (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SD/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/se/se-coa.json
+++ b/lists/se/se-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Sweden Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sweden.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/se/se-coa.json
+++ b/lists/se/se-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sweden.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sweden.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SE/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/sg/sg-coa.json
+++ b/lists/sg/sg-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SG/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SG"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Singapore.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Singapore.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SG/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/sg/sg-coa.json
+++ b/lists/sg/sg-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Singapore Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Singapore.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/si/si-coa.json
+++ b/lists/si/si-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SI/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SI"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Slovenia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Slovenia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SI/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/si/si-coa.json
+++ b/lists/si/si-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Slovenia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Slovenia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SI/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sk/sk-coa.json
+++ b/lists/sk/sk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Slovakia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Slovakia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sk/sk-coa.json
+++ b/lists/sk/sk-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SK/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SK"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Slovakia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Slovakia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SK/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/sl/sl-coa.json
+++ b/lists/sl/sl-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SL/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SL"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SL/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "101, 105",

--- a/lists/sl/sl-coa.json
+++ b/lists/sl/sl-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Sierra Leone Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SL/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101, 105",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/SL/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sm/sm-coa.json
+++ b/lists/sm/sm-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for San Marino.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for San Marino.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SM/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/sm/sm-coa.json
+++ b/lists/sm/sm-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "San Marino Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for San Marino.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sn/sn-coa.json
+++ b/lists/sn/sn-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SN/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SN"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SN/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "10, 21",

--- a/lists/sn/sn-coa.json
+++ b/lists/sn/sn-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Senegal Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SN/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "10, 21",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/SN/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/so/so-coa.json
+++ b/lists/so/so-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SO/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SO"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SO/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "101, 102",

--- a/lists/so/so-coa.json
+++ b/lists/so/so-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Somalia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SO/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101, 102",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/SO/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sr/sr-coa.json
+++ b/lists/sr/sr-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Suriname.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Suriname.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/sr/sr-coa.json
+++ b/lists/sr/sr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Suriname Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Suriname.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ss/ss-coa.json
+++ b/lists/ss/ss-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "South Sudan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for South Sudan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ss/ss-coa.json
+++ b/lists/ss/ss-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SS/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SS"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for South Sudan.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for South Sudan.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SS/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/st/st-coa.json
+++ b/lists/st/st-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Sao Tome and Principe Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ST/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ST"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ST-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sao Tome and Principe.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ST/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/st/st-coa.json
+++ b/lists/st/st-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/ST/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "ST"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sao Tome and Principe.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sao Tome and Principe.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ST/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/sv/sv-coa.json
+++ b/lists/sv/sv-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SV/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SV"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for El Salvador.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for El Salvador.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SV/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/sv/sv-coa.json
+++ b/lists/sv/sv-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "El Salvador Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SV/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SV"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SV-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for El Salvador.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SV/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sy/sy-coa.json
+++ b/lists/sy/sy-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SY/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SY"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Syrian Arab Republic (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Syrian Arab Republic (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SY/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/sy/sy-coa.json
+++ b/lists/sy/sy-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Syrian Arab Republic (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Syrian Arab Republic (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sz/sz-coa.json
+++ b/lists/sz/sz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Eswatini Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Eswatini.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sz/sz-coa.json
+++ b/lists/sz/sz-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/SZ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "SZ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Eswatini.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Eswatini.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SZ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/td/td-coa.json
+++ b/lists/td/td-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Chad Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TD/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 3",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/TD/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/td/td-coa.json
+++ b/lists/td/td-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TD/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "TD"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TD/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1, 3",

--- a/lists/tg/tg-coa.json
+++ b/lists/tg/tg-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TG/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "TG"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TG/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "210, 110",

--- a/lists/tg/tg-coa.json
+++ b/lists/tg/tg-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Togo Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TG/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "210, 110",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/TG/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/th/th-coa.json
+++ b/lists/th/th-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Thailand Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Thailand.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/th/th-coa.json
+++ b/lists/th/th-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TH/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "TH"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Thailand.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Thailand.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TH/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/tj/tj-coa.json
+++ b/lists/tj/tj-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Tajikistan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TJ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TJ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TJ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TJ/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "04 , 05 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/TJ/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tj/tj-coa.json
+++ b/lists/tj/tj-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TJ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "TJ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TJ/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "04 , 05 ",

--- a/lists/tl/tl-coa.json
+++ b/lists/tl/tl-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Timor-Leste Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TL/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/TL/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tl/tl-coa.json
+++ b/lists/tl/tl-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TL/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "TL"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TL/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1, 2",

--- a/lists/tn/tn-coa.json
+++ b/lists/tn/tn-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TN/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "TN"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Tunisia.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Tunisia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TN/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/tn/tn-coa.json
+++ b/lists/tn/tn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Tunisia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Tunisia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/to/to-coa.json
+++ b/lists/to/to-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TO/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "TO"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Tonga.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Tonga.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TO/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/to/to-coa.json
+++ b/lists/to/to-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Tonga Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Tonga.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tr/tr-coa.json
+++ b/lists/tr/tr-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TR/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "TR"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Turkey.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Turkey.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/tr/tr-coa.json
+++ b/lists/tr/tr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Turkey Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Turkey.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tt/tt-coa.json
+++ b/lists/tt/tt-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TT/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "TT"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Trinidad and Tobago.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Trinidad and Tobago.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TT/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/tt/tt-coa.json
+++ b/lists/tt/tt-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Trinidad and Tobago Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Trinidad and Tobago.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tw/tw-coa.json
+++ b/lists/tw/tw-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Taiwan (Province of China) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Taiwan (Province of China).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TW/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tw/tw-coa.json
+++ b/lists/tw/tw-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TW/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "TW"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Taiwan (Province of China).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Taiwan (Province of China).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TW/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/tz/tz-coa.json
+++ b/lists/tz/tz-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Tanzania, the United Republic of Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TZ/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "02, 03",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/TZ/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tz/tz-coa.json
+++ b/lists/tz/tz-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TZ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "TZ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TZ/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "02, 03",

--- a/lists/ua/ua-coa.json
+++ b/lists/ua/ua-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/UA/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "UA"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ukraine.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ukraine.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UA/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ua/ua-coa.json
+++ b/lists/ua/ua-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Ukraine Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/UA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "UA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "UA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ukraine.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ug/ug-coa.json
+++ b/lists/ug/ug-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/UG/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "UG"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UG/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "001, 002",

--- a/lists/ug/ug-coa.json
+++ b/lists/ug/ug-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Uganda Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/UG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "UG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "UG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UG/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "001, 002",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/UG/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/us/us-coa.json
+++ b/lists/us/us-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/US/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "US"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United States of America (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United States of America (the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/US/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/us/us-coa.json
+++ b/lists/us/us-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "United States of America (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/US/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "US"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "US-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United States of America (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/US/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/uy/uy-coa.json
+++ b/lists/uy/uy-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Uruguay Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/UY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "UY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "UY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Uruguay.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/uy/uy-coa.json
+++ b/lists/uy/uy-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/UY/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "UY"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Uruguay.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Uruguay.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UY/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/uz/uz-coa.json
+++ b/lists/uz/uz-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/UZ/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "UZ"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Uzbekistan.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Uzbekistan.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UZ/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/uz/uz-coa.json
+++ b/lists/uz/uz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Uzbekistan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/UZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "UZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "UZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Uzbekistan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/vc/vc-coa.json
+++ b/lists/vc/vc-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Saint Vincent and the Grenadines Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/VC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "VC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "VC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Vincent and the Grenadines.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/vc/vc-coa.json
+++ b/lists/vc/vc-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/VC/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "VC"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Vincent and the Grenadines.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Vincent and the Grenadines.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VC/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ve/ve-coa.json
+++ b/lists/ve/ve-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/VE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "VE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Venezuela (Bolivarian Republic of).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Venezuela (Bolivarian Republic of).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VE/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ve/ve-coa.json
+++ b/lists/ve/ve-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Venezuela (Bolivarian Republic of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/VE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "VE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "VE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Venezuela (Bolivarian Republic of).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/vn/vn-coa.json
+++ b/lists/vn/vn-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/VN/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "VN"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Viet Nam.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Viet Nam.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VN/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/vn/vn-coa.json
+++ b/lists/vn/vn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Viet Nam Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/VN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "VN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "VN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Viet Nam.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/vu/vu-coa.json
+++ b/lists/vu/vu-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/VU/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "VU"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Vanuatu.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Vanuatu.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VU/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/vu/vu-coa.json
+++ b/lists/vu/vu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Vanuatu Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/VU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "VU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "VU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Vanuatu.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ws/ws-coa.json
+++ b/lists/ws/ws-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Samoa Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/WS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "WS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "WS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Samoa.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/WS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ws/ws-coa.json
+++ b/lists/ws/ws-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/WS/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "WS"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Samoa.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Samoa.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/WS/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/xk/xk-coa.json
+++ b/lists/xk/xk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Kosovo Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/XK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "XK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "XK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kosovo.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/XK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/xk/xk-coa.json
+++ b/lists/xk/xk-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/XK/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "XK"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kosovo.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kosovo.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/XK/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ye/ye-coa.json
+++ b/lists/ye/ye-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Yemen Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/YE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "YE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "YE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Yemen.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/YE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ye/ye-coa.json
+++ b/lists/ye/ye-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/YE/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "YE"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Yemen.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Yemen.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/YE/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/za/za-coa.json
+++ b/lists/za/za-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "South Africa Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ZA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ZA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ZA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for South Africa.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ZA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/za/za-coa.json
+++ b/lists/za/za-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/ZA/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "ZA"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for South Africa.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for South Africa.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ZA/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",
@@ -29,7 +29,7 @@
   },
   "data": {
     "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/zm/zm-coa.json
+++ b/lists/zm/zm-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Zambia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ZM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ZM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ZM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ZM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01 , 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/ZM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/zm/zm-coa.json
+++ b/lists/zm/zm-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/ZM/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "ZM"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ZM/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "01 , 02 ",

--- a/lists/zw/zw-coa.json
+++ b/lists/zw/zw-coa.json
@@ -5,7 +5,7 @@
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/ZW/",
   "description": {
-    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
   },
   "coverage": [
     "ZW"
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ZW/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
     "exampleIdentifiers": "1, 2",

--- a/lists/zw/zw-coa.json
+++ b/lists/zw/zw-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Zimbabwe Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ZW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov ID Finder [1] from Development Initiatives. Where available, Gov ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ZW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ZW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ZW/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/ZW/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}


### PR DESCRIPTION
**This is the alternate PR. #500 is preferred.**

* Adds COA files for each country
* For countries that have codes on gov-id-finder.codeforiati.org, this is noted and example codes are given.
* For countries that do not have codes on gov-id-finder.codeforiati.org, users are encouraged to reach out and supply codes.

**Note: this PR does not make COA files where a country folder does not already exist.**

It also does not make a COA file for Afghanistan, as `AF-COA` already exists.