### PR TITLE
Add COA files for all countries from gov-id-finder.codeforiati.org

### DIFF
--- a/lists/ad/ad-coa.json
+++ b/lists/ad/ad-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Andorra Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Andorra.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AD/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ae/ae-coa.json
+++ b/lists/ae/ae-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "United Arab Emirates (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United Arab Emirates (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ag/ag-coa.json
+++ b/lists/ag/ag-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Antigua and Barbuda Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Antigua and Barbuda.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ai/ai-coa.json
+++ b/lists/ai/ai-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Anguilla Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Anguilla.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AI/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/al/al-coa.json
+++ b/lists/al/al-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Albania Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Albania.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/am/am-coa.json
+++ b/lists/am/am-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Armenia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101001, 101002",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/AM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ao/ao-coa.json
+++ b/lists/ao/ao-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Angola Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Angola.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/aq/aq-coa.json
+++ b/lists/aq/aq-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Antarctica Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AQ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AQ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AQ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Antarctica.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AQ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ar/ar-coa.json
+++ b/lists/ar/ar-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Argentina Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Argentina.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/as/as-coa.json
+++ b/lists/as/as-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "American Samoa Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for American Samoa.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/at/at-coa.json
+++ b/lists/at/at-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Austria Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Austria.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/au/au-coa.json
+++ b/lists/au/au-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Australia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Australia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/aw/aw-coa.json
+++ b/lists/aw/aw-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Aruba Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Aruba.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AW/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ax/ax-coa.json
+++ b/lists/ax/ax-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "\u00c5land Islands Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AX/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AX"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AX-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for \u00c5land Islands.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AX/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/az/az-coa.json
+++ b/lists/az/az-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Azerbaijan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/AZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "AZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "AZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Azerbaijan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/AZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ba/ba-coa.json
+++ b/lists/ba/ba-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bosnia and Herzegovina Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bosnia and Herzegovina.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bb/bb-coa.json
+++ b/lists/bb/bb-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Barbados Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BB/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BB"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BB-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Barbados.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BB/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bd/bd-coa.json
+++ b/lists/bd/bd-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Bangladesh Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BD/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101, 102",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BD/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/be/be-coa.json
+++ b/lists/be/be-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Belgium Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belgium.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bf/bf-coa.json
+++ b/lists/bf/bf-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Burkina Faso Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BF/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BF"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BF-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BF/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "14, 1",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BF/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bg/bg-coa.json
+++ b/lists/bg/bg-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bulgaria Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bulgaria.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bh/bh-coa.json
+++ b/lists/bh/bh-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bahrain Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bahrain.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bi/bi-coa.json
+++ b/lists/bi/bi-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Burundi Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BI/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BI/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bj/bj-coa.json
+++ b/lists/bj/bj-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Benin Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BJ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BJ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BJ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Benin.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BJ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bl/bl-coa.json
+++ b/lists/bl/bl-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Saint Barth\u00e9lemy Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Barth\u00e9lemy.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bm/bm-coa.json
+++ b/lists/bm/bm-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bermuda Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bermuda.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bn/bn-coa.json
+++ b/lists/bn/bn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Brunei Darussalam Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Brunei Darussalam.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bo/bo-coa.json
+++ b/lists/bo/bo-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Bolivia (Plurinational State of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BO/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "0006, 0010",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BO/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bq/bq-coa.json
+++ b/lists/bq/bq-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bonaire, Sint Eustatius and Saba Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BQ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BQ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BQ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bonaire, Sint Eustatius and Saba.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BQ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/br/br-coa.json
+++ b/lists/br/br-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Brazil Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Brazil.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bs/bs-coa.json
+++ b/lists/bs/bs-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bahamas (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bahamas (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bt/bt-coa.json
+++ b/lists/bt/bt-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Bhutan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BT/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101.01, 102.01",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BT/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bv/bv-coa.json
+++ b/lists/bv/bv-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Bouvet Island Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BV/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BV"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BV-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Bouvet Island.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BV/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bw/bw-coa.json
+++ b/lists/bw/bw-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Botswana Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Botswana.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BW/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/by/by-coa.json
+++ b/lists/by/by-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Belarus Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belarus.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/bz/bz-coa.json
+++ b/lists/bz/bz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Belize Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/BZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "BZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "BZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Belize.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ca/ca-coa.json
+++ b/lists/ca/ca-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Canada Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Canada.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cc/cc-coa.json
+++ b/lists/cc/cc-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Cocos (Keeling) Islands (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cocos (Keeling) Islands (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cd/cd-coa.json
+++ b/lists/cd/cd-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Congo (the Democratic Republic of the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CD/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "10, 11",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/CD/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cf/cf-coa.json
+++ b/lists/cf/cf-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Central African Republic (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CF/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CF"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CF-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CF/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/CF/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cg/cg-coa.json
+++ b/lists/cg/cg-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Congo (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Congo (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ch/ch-coa.json
+++ b/lists/ch/ch-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Switzerland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Switzerland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ci/ci-coa.json
+++ b/lists/ci/ci-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "C\u00f4te d'Ivoire Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CI/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/CI/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ck/ck-coa.json
+++ b/lists/ck/ck-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Cook Islands (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cook Islands (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cl/cl-coa.json
+++ b/lists/cl/cl-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Chile Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Chile.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cm/cm-coa.json
+++ b/lists/cm/cm-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Cameroon Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01 , 02",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/CM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cn/cn-coa.json
+++ b/lists/cn/cn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "China Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for China.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/co/co-coa.json
+++ b/lists/co/co-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Colombia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Colombia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cr/cr-coa.json
+++ b/lists/cr/cr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Costa Rica Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Costa Rica.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cu/cu-coa.json
+++ b/lists/cu/cu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Cuba Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cuba.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cv/cv-coa.json
+++ b/lists/cv/cv-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Cabo Verde Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CV/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CV"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CV-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cabo Verde.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CV/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cw/cw-coa.json
+++ b/lists/cw/cw-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Cura\u00e7ao Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cura\u00e7ao.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CW/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cx/cx-coa.json
+++ b/lists/cx/cx-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Christmas Island Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CX/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CX"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CX-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Christmas Island.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CX/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cy/cy-coa.json
+++ b/lists/cy/cy-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Cyprus Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cyprus.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/cz/cz-coa.json
+++ b/lists/cz/cz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Czechia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/CZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "CZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "CZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Czechia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/de/de-coa.json
+++ b/lists/de/de-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Germany Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Germany.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/dj/dj-coa.json
+++ b/lists/dj/dj-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Djibouti Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DJ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DJ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DJ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Djibouti.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DJ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/dk/dk-coa.json
+++ b/lists/dk/dk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Denmark Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Denmark.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/dm/dm-coa.json
+++ b/lists/dm/dm-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Dominica Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Dominica.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/do/do-coa.json
+++ b/lists/do/do-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Dominican Republic (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Dominican Republic (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/dz/dz-coa.json
+++ b/lists/dz/dz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Algeria Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/DZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "DZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "DZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Algeria.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/DZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ec/ec-coa.json
+++ b/lists/ec/ec-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Ecuador Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/EC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "EC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "EC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ecuador.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/EC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ee/ee-coa.json
+++ b/lists/ee/ee-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Estonia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/EE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "EE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "EE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Estonia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/EE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/eg/eg-coa.json
+++ b/lists/eg/eg-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Egypt Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/EG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "EG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "EG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Egypt.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/EG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/eh/eh-coa.json
+++ b/lists/eh/eh-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Western Sahara Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/EH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "EH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "EH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Western Sahara.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/EH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/er/er-coa.json
+++ b/lists/er/er-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Eritrea Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ER/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ER"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ER-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Eritrea.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ER/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/es/es-coa.json
+++ b/lists/es/es-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Spain Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ES/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ES"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ES-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Spain.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ES/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/et/et-coa.json
+++ b/lists/et/et-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Ethiopia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ET/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ET"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ET-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ET/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "100, 110",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/ET/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/fi/fi-coa.json
+++ b/lists/fi/fi-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Finland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/FI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "FI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "FI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Finland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FI/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/fj/fj-coa.json
+++ b/lists/fj/fj-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Fiji Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/FJ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "FJ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "FJ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Fiji.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FJ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/fk/fk-coa.json
+++ b/lists/fk/fk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Falkland Islands (the) [Malvinas] Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/FK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "FK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "FK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Falkland Islands (the) [Malvinas].",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/fm/fm-coa.json
+++ b/lists/fm/fm-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Micronesia (Federated States of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/FM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "FM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "FM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Micronesia (Federated States of).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/fo/fo-coa.json
+++ b/lists/fo/fo-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Faroe Islands (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/FO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "FO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "FO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Faroe Islands (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/fr/fr-coa.json
+++ b/lists/fr/fr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "France Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/FR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "FR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "FR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for France.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/FR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ga/ga-coa.json
+++ b/lists/ga/ga-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Gabon Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Gabon.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gb/gb-coa.json
+++ b/lists/gb/gb-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "United Kingdom of Great Britain and Northern Ireland (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GB/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GB"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GB-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United Kingdom of Great Britain and Northern Ireland (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GB/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gd/gd-coa.json
+++ b/lists/gd/gd-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Grenada Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Grenada.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GD/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ge/ge-coa.json
+++ b/lists/ge/ge-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Georgia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Georgia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gf/gf-coa.json
+++ b/lists/gf/gf-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "French Guiana Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GF/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GF"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GF-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for French Guiana.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GF/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gg/gg-coa.json
+++ b/lists/gg/gg-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Guernsey Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guernsey.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gh/gh-coa.json
+++ b/lists/gh/gh-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Ghana Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GH/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/GH/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gi/gi-coa.json
+++ b/lists/gi/gi-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Gibraltar Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Gibraltar.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GI/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gl/gl-coa.json
+++ b/lists/gl/gl-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Greenland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Greenland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gm/gm-coa.json
+++ b/lists/gm/gm-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Gambia (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01 , 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/GM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gn/gn-coa.json
+++ b/lists/gn/gn-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Guinea Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GN/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "04, 06",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/GN/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gp/gp-coa.json
+++ b/lists/gp/gp-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Guadeloupe Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GP/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GP"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GP-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guadeloupe.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GP/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gq/gq-coa.json
+++ b/lists/gq/gq-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Equatorial Guinea Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GQ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GQ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GQ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Equatorial Guinea.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GQ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gr/gr-coa.json
+++ b/lists/gr/gr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Greece Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Greece.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gs/gs-coa.json
+++ b/lists/gs/gs-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "South Georgia and the South Sandwich Islands Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for South Georgia and the South Sandwich Islands.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gt/gt-coa.json
+++ b/lists/gt/gt-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Guatemala Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guatemala.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gu/gu-coa.json
+++ b/lists/gu/gu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Guam Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guam.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gw/gw-coa.json
+++ b/lists/gw/gw-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Guinea-Bissau Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GW/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 6",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/GW/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/gy/gy-coa.json
+++ b/lists/gy/gy-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Guyana Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/GY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "GY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "GY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Guyana.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/hk/hk-coa.json
+++ b/lists/hk/hk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Hong Kong Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/HK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "HK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "HK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Hong Kong.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/hm/hm-coa.json
+++ b/lists/hm/hm-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Heard Island and McDonald Islands Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/HM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "HM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "HM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Heard Island and McDonald Islands.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/hn/hn-coa.json
+++ b/lists/hn/hn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Honduras Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/HN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "HN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "HN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Honduras.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/hr/hr-coa.json
+++ b/lists/hr/hr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Croatia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/HR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "HR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "HR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Croatia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ht/ht-coa.json
+++ b/lists/ht/ht-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Haiti Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/HT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "HT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "HT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HT/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1111, 1112",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/HT/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/hu/hu-coa.json
+++ b/lists/hu/hu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Hungary Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/HU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "HU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "HU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Hungary.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/HU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/id/id-coa.json
+++ b/lists/id/id-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Indonesia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ID/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ID"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ID-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ID/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/ID/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ie/ie-coa.json
+++ b/lists/ie/ie-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Ireland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ireland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/il/il-coa.json
+++ b/lists/il/il-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Israel Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Israel.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/im/im-coa.json
+++ b/lists/im/im-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Isle of Man Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Isle of Man.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/in/in-coa.json
+++ b/lists/in/in-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "India Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for India.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/io/io-coa.json
+++ b/lists/io/io-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "British Indian Ocean Territory (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for British Indian Ocean Territory (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/iq/iq-coa.json
+++ b/lists/iq/iq-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Iraq Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IQ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IQ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IQ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iraq.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IQ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ir/ir-coa.json
+++ b/lists/ir/ir-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Iran (Islamic Republic of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iran (Islamic Republic of).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/is/is-coa.json
+++ b/lists/is/is-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Iceland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Iceland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/it/it-coa.json
+++ b/lists/it/it-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Italy Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/IT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "IT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "IT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Italy.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/IT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/je/je-coa.json
+++ b/lists/je/je-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Jersey Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/JE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "JE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "JE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Jersey.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/jm/jm-coa.json
+++ b/lists/jm/jm-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Jamaica Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/JM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "JM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "JM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1000, 2000",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/JM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/jo/jo-coa.json
+++ b/lists/jo/jo-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Jordan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/JO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "JO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "JO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JO/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "0101, 0201",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/JO/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/jp/jp-coa.json
+++ b/lists/jp/jp-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Japan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/JP/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "JP"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "JP-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Japan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/JP/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ke/ke-coa.json
+++ b/lists/ke/ke-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Kenya Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KE/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "110, 119",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KE/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kg/kg-coa.json
+++ b/lists/kg/kg-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Kyrgyzstan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KG/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "11, 11",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KG/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kh/kh-coa.json
+++ b/lists/kh/kh-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Cambodia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KH/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KH/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ki/ki-coa.json
+++ b/lists/ki/ki-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Kiribati Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KI/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 11",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KI/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/km/km-coa.json
+++ b/lists/km/km-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Comoros (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Comoros (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kn/kn-coa.json
+++ b/lists/kn/kn-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Saint Kitts and Nevis Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KN/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KN/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kp/kp-coa.json
+++ b/lists/kp/kp-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Korea (the Democratic People's Republic of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KP/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KP"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KP-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Korea (the Democratic People's Republic of).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KP/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kr/kr-coa.json
+++ b/lists/kr/kr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Korea (the Republic of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Korea (the Republic of).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kw/kw-coa.json
+++ b/lists/kw/kw-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Kuwait Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kuwait.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KW/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ky/ky-coa.json
+++ b/lists/ky/ky-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Cayman Islands (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cayman Islands (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/kz/kz-coa.json
+++ b/lists/kz/kz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Kazakhstan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/KZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "KZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "KZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kazakhstan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/la/la-coa.json
+++ b/lists/la/la-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Lao People's Democratic Republic (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LA/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/LA/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lb/lb-coa.json
+++ b/lists/lb/lb-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Lebanon Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LB/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LB"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LB-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Lebanon.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LB/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lc/lc-coa.json
+++ b/lists/lc/lc-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Saint Lucia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Lucia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/li/li-coa.json
+++ b/lists/li/li-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Liechtenstein Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Liechtenstein.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LI/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lk/lk-coa.json
+++ b/lists/lk/lk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Sri Lanka Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sri Lanka.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lr/lr-coa.json
+++ b/lists/lr/lr-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Liberia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LR/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101, 104",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/LR/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ls/ls-coa.json
+++ b/lists/ls/ls-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Lesotho Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LS/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "001, 002",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/LS/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lt/lt-coa.json
+++ b/lists/lt/lt-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Lithuania Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Lithuania.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lu/lu-coa.json
+++ b/lists/lu/lu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Luxembourg Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Luxembourg.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/lv/lv-coa.json
+++ b/lists/lv/lv-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Latvia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LV/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LV"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LV-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Latvia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LV/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ly/ly-coa.json
+++ b/lists/ly/ly-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Libya Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/LY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "LY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "LY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Libya.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/LY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ma/ma-coa.json
+++ b/lists/ma/ma-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Morocco Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Morocco.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mc/mc-coa.json
+++ b/lists/mc/mc-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Monaco Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Monaco.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/md/md-coa.json
+++ b/lists/md/md-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Moldova (the Republic of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Moldova (the Republic of).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MD/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/me/me-coa.json
+++ b/lists/me/me-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Montenegro Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ME/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ME"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ME-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Montenegro.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ME/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mf/mf-coa.json
+++ b/lists/mf/mf-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Saint Martin (French part) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MF/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MF"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MF-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Martin (French part).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MF/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mg/mg-coa.json
+++ b/lists/mg/mg-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Madagascar Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MG/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01 , 02",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/MG/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mh/mh-coa.json
+++ b/lists/mh/mh-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Marshall Islands (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Marshall Islands (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mk/mk-coa.json
+++ b/lists/mk/mk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "North Macedonia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for North Macedonia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ml/ml-coa.json
+++ b/lists/ml/ml-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Mali Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ML/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ML"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ML-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ML/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "110, 110",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/ML/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mm/mm-coa.json
+++ b/lists/mm/mm-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Myanmar Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/MM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mn/mn-coa.json
+++ b/lists/mn/mn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Mongolia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mongolia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mo/mo-coa.json
+++ b/lists/mo/mo-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Macao Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Macao.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mp/mp-coa.json
+++ b/lists/mp/mp-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Northern Mariana Islands (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MP/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MP"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MP-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Northern Mariana Islands (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MP/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mq/mq-coa.json
+++ b/lists/mq/mq-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Martinique Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MQ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MQ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MQ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Martinique.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MQ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mr/mr-coa.json
+++ b/lists/mr/mr-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Mauritania Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MR/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "12, 17",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/MR/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ms/ms-coa.json
+++ b/lists/ms/ms-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Montserrat Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Montserrat.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mt/mt-coa.json
+++ b/lists/mt/mt-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Malta Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Malta.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mu/mu-coa.json
+++ b/lists/mu/mu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Mauritius Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mauritius.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mv/mv-coa.json
+++ b/lists/mv/mv-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Maldives Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MV/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MV"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MV-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Maldives.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MV/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mw/mw-coa.json
+++ b/lists/mw/mw-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Malawi Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MW/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "010 , 020 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/MW/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mx/mx-coa.json
+++ b/lists/mx/mx-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Mexico Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MX/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MX"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MX-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mexico.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MX/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/my/my-coa.json
+++ b/lists/my/my-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Malaysia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Malaysia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/mz/mz-coa.json
+++ b/lists/mz/mz-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Mozambique Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/MZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "MZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "MZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MZ/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01A000141, 01A000541",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/MZ/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/na/na-coa.json
+++ b/lists/na/na-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Namibia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Namibia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/nc/nc-coa.json
+++ b/lists/nc/nc-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "New Caledonia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for New Caledonia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ne/ne-coa.json
+++ b/lists/ne/ne-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Niger (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NE/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "47, 0",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/NE/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/nf/nf-coa.json
+++ b/lists/nf/nf-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Norfolk Island Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NF/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NF"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NF-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Norfolk Island.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NF/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ng/ng-coa.json
+++ b/lists/ng/ng-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Nigeria Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Nigeria.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ni/ni-coa.json
+++ b/lists/ni/ni-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Nicaragua Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NI/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/NI/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/nl/nl-coa.json
+++ b/lists/nl/nl-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Netherlands (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Netherlands (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/no/no-coa.json
+++ b/lists/no/no-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Norway Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Norway.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/np/np-coa.json
+++ b/lists/np/np-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Nepal Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NP/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NP"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NP-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NP/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101, 102",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/NP/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/nr/nr-coa.json
+++ b/lists/nr/nr-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Nauru Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NR/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/NR/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/nu/nu-coa.json
+++ b/lists/nu/nu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Niue Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Niue.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/nz/nz-coa.json
+++ b/lists/nz/nz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "New Zealand Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/NZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "NZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "NZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for New Zealand.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/om/om-coa.json
+++ b/lists/om/om-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Oman Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/OM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "OM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "OM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Oman.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/OM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pa/pa-coa.json
+++ b/lists/pa/pa-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Panama Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Panama.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pe/pe-coa.json
+++ b/lists/pe/pe-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Peru Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Peru.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pf/pf-coa.json
+++ b/lists/pf/pf-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "French Polynesia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PF/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PF"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PF-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for French Polynesia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PF/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pg/pg-coa.json
+++ b/lists/pg/pg-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Papua New Guinea Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PG/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "201, 202",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/PG/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ph/ph-coa.json
+++ b/lists/ph/ph-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Philippines (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Philippines (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pk/pk-coa.json
+++ b/lists/pk/pk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Pakistan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Pakistan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pl/pl-coa.json
+++ b/lists/pl/pl-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Poland Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Poland.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PL/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pm/pm-coa.json
+++ b/lists/pm/pm-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Saint Pierre and Miquelon Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Pierre and Miquelon.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pn/pn-coa.json
+++ b/lists/pn/pn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Pitcairn Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Pitcairn.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pr/pr-coa.json
+++ b/lists/pr/pr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Puerto Rico Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Puerto Rico.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ps/ps-coa.json
+++ b/lists/ps/ps-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Palestine, State of Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Palestine, State of.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pt/pt-coa.json
+++ b/lists/pt/pt-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Portugal Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Portugal.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/pw/pw-coa.json
+++ b/lists/pw/pw-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Palau Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PW/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/PW/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/py/py-coa.json
+++ b/lists/py/py-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Paraguay Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/PY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "PY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "PY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Paraguay.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/qa/qa-coa.json
+++ b/lists/qa/qa-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Qatar Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/QA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "QA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "QA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Qatar.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/QA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/re/re-coa.json
+++ b/lists/re/re-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "R\u00e9union Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/RE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "RE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "RE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for R\u00e9union.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ro/ro-coa.json
+++ b/lists/ro/ro-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Romania Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/RO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "RO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "RO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Romania.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/rs/rs-coa.json
+++ b/lists/rs/rs-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Serbia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/RS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "RS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "RS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Serbia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ru/ru-coa.json
+++ b/lists/ru/ru-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Russian Federation (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/RU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "RU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "RU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Russian Federation (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/rw/rw-coa.json
+++ b/lists/rw/rw-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Rwanda Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/RW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "RW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "RW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RW/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/RW/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sa/sa-coa.json
+++ b/lists/sa/sa-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Saudi Arabia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saudi Arabia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sb/sb-coa.json
+++ b/lists/sb/sb-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Solomon Islands Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SB/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SB"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SB-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SB/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "470, 474",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/SB/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sc/sc-coa.json
+++ b/lists/sc/sc-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Seychelles Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Seychelles.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sd/sd-coa.json
+++ b/lists/sd/sd-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Sudan (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sudan (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SD/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/se/se-coa.json
+++ b/lists/se/se-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Sweden Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sweden.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sg/sg-coa.json
+++ b/lists/sg/sg-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Singapore Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Singapore.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sh/sh-coa.json
+++ b/lists/sh/sh-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Saint Helena, Ascension and Tristan da Cunha Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Helena, Ascension and Tristan da Cunha.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/si/si-coa.json
+++ b/lists/si/si-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Slovenia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Slovenia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SI/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sj/sj-coa.json
+++ b/lists/sj/sj-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Svalbard and Jan Mayen Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SJ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SJ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SJ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Svalbard and Jan Mayen.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SJ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sk/sk-coa.json
+++ b/lists/sk/sk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Slovakia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Slovakia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sl/sl-coa.json
+++ b/lists/sl/sl-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Sierra Leone Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SL/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101, 105",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/SL/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sm/sm-coa.json
+++ b/lists/sm/sm-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "San Marino Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for San Marino.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sn/sn-coa.json
+++ b/lists/sn/sn-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Senegal Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SN/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "10, 21",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/SN/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/so/so-coa.json
+++ b/lists/so/so-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Somalia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SO/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "101, 102",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/SO/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sr/sr-coa.json
+++ b/lists/sr/sr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Suriname Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Suriname.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ss/ss-coa.json
+++ b/lists/ss/ss-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "South Sudan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for South Sudan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/st/st-coa.json
+++ b/lists/st/st-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Sao Tome and Principe Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ST/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ST"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ST-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sao Tome and Principe.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ST/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sv/sv-coa.json
+++ b/lists/sv/sv-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "El Salvador Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SV/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SV"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SV-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for El Salvador.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SV/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sx/sx-coa.json
+++ b/lists/sx/sx-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Sint Maarten (Dutch part) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SX/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SX"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SX-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Sint Maarten (Dutch part).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SX/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sy/sy-coa.json
+++ b/lists/sy/sy-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Syrian Arab Republic (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Syrian Arab Republic (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/sz/sz-coa.json
+++ b/lists/sz/sz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Eswatini Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/SZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "SZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "SZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Eswatini.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tc/tc-coa.json
+++ b/lists/tc/tc-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Turks and Caicos Islands (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Turks and Caicos Islands (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/td/td-coa.json
+++ b/lists/td/td-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Chad Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TD/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TD"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TD-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TD/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 3",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/TD/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tf/tf-coa.json
+++ b/lists/tf/tf-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "French Southern Territories (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TF/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TF"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TF-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for French Southern Territories (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TF/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tg/tg-coa.json
+++ b/lists/tg/tg-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Togo Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TG/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "210, 110",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/TG/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/th/th-coa.json
+++ b/lists/th/th-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Thailand Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TH/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TH"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TH-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Thailand.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TH/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tj/tj-coa.json
+++ b/lists/tj/tj-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Tajikistan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TJ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TJ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TJ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TJ/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "04 , 05 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/TJ/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tk/tk-coa.json
+++ b/lists/tk/tk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Tokelau Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Tokelau.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tl/tl-coa.json
+++ b/lists/tl/tl-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Timor-Leste Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TL/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TL"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TL-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TL/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/TL/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tm/tm-coa.json
+++ b/lists/tm/tm-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Turkmenistan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Turkmenistan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tn/tn-coa.json
+++ b/lists/tn/tn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Tunisia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Tunisia.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/to/to-coa.json
+++ b/lists/to/to-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Tonga Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TO/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TO"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TO-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Tonga.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TO/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tr/tr-coa.json
+++ b/lists/tr/tr-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Turkey Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TR/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TR"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TR-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Turkey.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TR/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tt/tt-coa.json
+++ b/lists/tt/tt-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Trinidad and Tobago Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Trinidad and Tobago.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tv/tv-coa.json
+++ b/lists/tv/tv-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Tuvalu Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TV/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TV"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TV-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Tuvalu.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TV/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tw/tw-coa.json
+++ b/lists/tw/tw-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Taiwan (Province of China) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Taiwan (Province of China).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TW/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/tz/tz-coa.json
+++ b/lists/tz/tz-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Tanzania, the United Republic of Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/TZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "TZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "TZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TZ/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "02, 03",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/TZ/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ua/ua-coa.json
+++ b/lists/ua/ua-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Ukraine Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/UA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "UA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "UA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Ukraine.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ug/ug-coa.json
+++ b/lists/ug/ug-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Uganda Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/UG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "UG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "UG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UG/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "001, 002",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/UG/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/um/um-coa.json
+++ b/lists/um/um-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "United States Minor Outlying Islands (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/UM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "UM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "UM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United States Minor Outlying Islands (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UM/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/us/us-coa.json
+++ b/lists/us/us-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "United States of America (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/US/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "US"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "US-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for United States of America (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/US/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/uy/uy-coa.json
+++ b/lists/uy/uy-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Uruguay Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/UY/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "UY"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "UY-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Uruguay.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UY/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/uz/uz-coa.json
+++ b/lists/uz/uz-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Uzbekistan Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/UZ/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "UZ"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "UZ-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Uzbekistan.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/UZ/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/va/va-coa.json
+++ b/lists/va/va-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Holy See (the) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/VA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "VA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "VA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Holy See (the).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/vc/vc-coa.json
+++ b/lists/vc/vc-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Saint Vincent and the Grenadines Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/VC/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "VC"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "VC-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Saint Vincent and the Grenadines.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VC/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ve/ve-coa.json
+++ b/lists/ve/ve-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Venezuela (Bolivarian Republic of) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/VE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "VE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "VE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Venezuela (Bolivarian Republic of).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/vg/vg-coa.json
+++ b/lists/vg/vg-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Virgin Islands (British) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/VG/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "VG"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "VG-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Virgin Islands (British).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VG/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/vi/vi-coa.json
+++ b/lists/vi/vi-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Virgin Islands (U.S.) Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/VI/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "VI"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "VI-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Virgin Islands (U.S.).",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VI/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/vn/vn-coa.json
+++ b/lists/vn/vn-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Viet Nam Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/VN/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "VN"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "VN-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Viet Nam.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VN/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/vu/vu-coa.json
+++ b/lists/vu/vu-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Vanuatu Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/VU/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "VU"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "VU-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Vanuatu.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/VU/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/wf/wf-coa.json
+++ b/lists/wf/wf-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Wallis and Futuna Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/WF/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "WF"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "WF-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Wallis and Futuna.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/WF/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ws/ws-coa.json
+++ b/lists/ws/ws-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Samoa Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/WS/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "WS"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "WS-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Samoa.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/WS/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/xk/xk-coa.json
+++ b/lists/xk/xk-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Kosovo Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/XK/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "XK"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "XK-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kosovo.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/XK/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/ye/ye-coa.json
+++ b/lists/ye/ye-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Yemen Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/YE/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "YE"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "YE-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Yemen.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/YE/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/yt/yt-coa.json
+++ b/lists/yt/yt-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "Mayotte Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/YT/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "YT"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "YT-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Mayotte.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/YT/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/za/za-coa.json
+++ b/lists/za/za-coa.json
@@ -1,0 +1,46 @@
+{
+  "name": {
+    "en": "South Africa Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ZA/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ZA"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ZA-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for South Africa.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ZA/",
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/zm/zm-coa.json
+++ b/lists/zm/zm-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Zambia Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ZM/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ZM"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ZM-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ZM/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01 , 02 ",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/ZM/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}

--- a/lists/zw/zw-coa.json
+++ b/lists/zw/zw-coa.json
@@ -1,0 +1,51 @@
+{
+  "name": {
+    "en": "Zimbabwe Chart of Accounts",
+    "local": ""
+  },
+  "url": "https://gov-id-finder.codeforiati.org/countries/ZW/",
+  "description": {
+    "en": "A government's budget (or 'Chart of Accounts') often refers to government agencies, departments and ministries with stable codes. These can be reliably used in open data publications as identifiers.\n\nThis org-id.guide entry is generated and maintained by Gov Org ID Finder [1] from Development Initiatives. Where available, Gov Org ID Finder extracts and makes Chart of Accounts codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.\n\n[1] https://gov-id-finder.codeforiati.org/about"
+  },
+  "coverage": [
+    "ZW"
+  ],
+  "subnationalCoverage": [],
+  "structure": [
+    "government_agency"
+  ],
+  "sector": [],
+  "code": "ZW-COA",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ZW/",
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "1, 2",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/ZW/",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Desk research",
+    "lastUpdated": "2022-03-23"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": ""
+  },
+  "formerPrefixes": []
+}


### PR DESCRIPTION
**This is the preferred PR. #499 is an alternative.**

* Adds COA files for each country
* For countries that have codes on gov-id-finder.codeforiati.org, this is noted and example codes are given.
* For countries that do not have codes on gov-id-finder.codeforiati.org, users are encouraged to reach out and supply codes.

**Note: this PR makes COA files even where a country folder does not already exist.**

It does not make a COA file for Afghanistan, as `AF-COA` already exists.