### PR TITLE
Replacing hypen with underscore in CH-BS-CR org list code

### DIFF
--- a/lists/ch/ch-bs-cr.json
+++ b/lists/ch/ch-bs-cr.json
@@ -17,7 +17,7 @@
     "company"
   ],
   "sector": [],
-  "code": "CH-BS-CR",
+  "code": "CH_BS-CR",
   "confirmed": true,
   "deprecated": false,
   "listType": "primary",
@@ -50,7 +50,7 @@
     "opencorporates": "",
     "wikipedia": ""
   },
-  "formerPrefixes": [],
+  "formerPrefixes": ["CH-BS-CR"],
   "meta": {
     "source": "Original research and official records",
     "lastUpdated": "2022-03-25"


### PR DESCRIPTION
This change is in response to the [comment and exchange](https://github.com/org-id/register/pull/502#issuecomment-1103707920) on a recent merged PR.

This would go alongside a [change](https://github.com/org-id/handbook/pull/25) to the handbook guidance, to introduce some consistency.
