### PR TITLE
Fix #536 - Update SO-MPND urls

### DIFF
--- a/lists/so/so-mpnd.json
+++ b/lists/so/so-mpnd.json
@@ -5,11 +5,7 @@
   },
   "url": "https://mopnd.govsomaliland.org/article/about-mopnd/",
   "description": {
-    "en": "This Ministry covers the registration and operation of non-governmental, independent and not-for-profit organizations within Somaliland (Local, National and International NGOs). Registrations have to be regularly renewed. International NGOs can register or renew their certificates at https://mopnd.govsomaliland.org/articles/new-registration and local NGOs at https://mopnd.govsomaliland.org/articles/new-registration-2.
-    \n\nLocal NGOs will be assigned with an identifier after registering. International NGOs should provide a copy of their home-country registration details. 
-    \n\nThe list does not include any regulation for the activities of UN organizations, Professional Associations, Private Companies, Industrial and Employee Associations, or those not relating to humanitarian activities. 
-    \n\nThe General Register for Non-Governmental Organizations records and maintains all information and data relating to NGOs. It has separate registration sections for National, International, Foreign, and Umbrellas NGOs. 
-    \n\nAn NGO is entered into the General Register using the official name of the NGO and the date of registration, serial number and registration number of the certificate."
+    "en": "This Ministry covers the registration and operation of non-governmental, independent and not-for-profit organizations within Somaliland (Local, National and International NGOs). Registrations have to be regularly renewed. International NGOs can register or renew their certificates at https://mopnd.govsomaliland.org/articles/new-registration and local NGOs at https://mopnd.govsomaliland.org/articles/new-registration-2.\n\nLocal NGOs will be assigned with an identifier after registering. International NGOs should provide a copy of their home-country registration details.\n\nThe list does not include any regulation for the activities of UN organizations, Professional Associations, Private Companies, Industrial and Employee Associations, or those not relating to humanitarian activities.\n\nThe General Register for Non-Governmental Organizations records and maintains all information and data relating to NGOs. It has separate registration sections for National, International, Foreign, and Umbrellas NGOs.\n\nAn NGO is entered into the General Register using the official name of the NGO and the date of registration, serial number and registration number of the certificate."
   },
   "coverage": [
     "SO"

--- a/lists/so/so-mpnd.json
+++ b/lists/so/so-mpnd.json
@@ -1,11 +1,15 @@
 {
   "name": {
-    "en": "General Register for Non-Governmental Organizations (Somaliland)",
+    "en": "Ministry of Planning and National Development - General Register for Non-Governmental Organizations (Somaliland)",
     "local": ""
   },
-  "url": "http://slministryofplanning.org/",
+  "url": "https://mopnd.govsomaliland.org/article/about-mopnd/",
   "description": {
-    "en": "(1) This list covers the operations of non-governmental, independent and not-for-profit organizations; Local/National NGOs, Foreign NGOs, and International NGOs within Somaliland. It also includes the Umbrellas and Consortium of Non-governmental Organizations[1]. Registrations have to be regularly renewed.\n\nLocal NGOs will be assigned with an identifier after registering. International NGOs should provide a copy of their home-country registration details. \n\nThe list does not include any regulation for the activities of UN organizations, Professional Associations, Private Companies and Industrial and Employee Associations, and those not relating to humanitarian activities [2]. \n\nThe General Register for Non-Governmental Organizations records and maintains all information and data relating to NGOs. The General Register has separate registration sections for National, International, Foreign, and Umbrellas NGOs [3]. \n\n(2) An NGO is entered into the General Register using the official name of the NGO and the date of registration, serial number and registration number of the certificate. Additional requirements also exist [4].\n\n[1]: Article2.2 and 2.3: http://slministryofplanning.org/images/NGO/ngo-law-final.pdf\n[2]: Article2.4: http://slministryofplanning.org/images/NGO/ngo-law-final.pdf\n[3]: Article 9.1: Register for Non-Governmental Organizations in http://slministryofplanning.org/images/NGO/ngo-law-final.pdf\n[4]: Article 9.7(f):  Register for Non-Governmental Organizations in http://slministryofplanning.org/images/NGO/ngo-law-final.pdf"
+    "en": "This Ministry covers the registration and operation of non-governmental, independent and not-for-profit organizations within Somaliland (Local, National and International NGOs). Registrations have to be regularly renewed. International NGOs can register or renew their certificates at https://mopnd.govsomaliland.org/articles/new-registration and local NGOs at https://mopnd.govsomaliland.org/articles/new-registration-2.
+    \n\nLocal NGOs will be assigned with an identifier after registering. International NGOs should provide a copy of their home-country registration details. 
+    \n\nThe list does not include any regulation for the activities of UN organizations, Professional Associations, Private Companies, Industrial and Employee Associations, or those not relating to humanitarian activities. 
+    \n\nThe General Register for Non-Governmental Organizations records and maintains all information and data relating to NGOs. It has separate registration sections for National, International, Foreign, and Umbrellas NGOs. 
+    \n\nAn NGO is entered into the General Register using the official name of the NGO and the date of registration, serial number and registration number of the certificate."
   },
   "coverage": [
     "SO"
@@ -25,7 +29,7 @@
     "onlineAccessDetails": "",
     "publicDatabase": "",
     "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
+    "exampleIdentifiers": "L43135002018MJ",
     "languages": [
       ""
     ]
@@ -41,7 +45,7 @@
   },
   "meta": {
     "source": "Original research - https://github.com/org-id/register/issues/205",
-    "lastUpdated": "2018-04-18"
+    "lastUpdated": "2023-08-14"
   },
   "links": {
     "opencorporates": "",


### PR DESCRIPTION
Fix #536 
- The Ministry of Planning urls on the org-id SO-MPND page have been updated (the old domain has been taken over and these links are no longer safe). 
- Old urls have been removed or replaced in the description 
- An example SO-MPND identifier has been added.