### PR TITLE
2024 Updates from gov-id-finder

### DIFF
--- a/lists/bf/bf-coa.json
+++ b/lists/bf/bf-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BF/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "14, 1",
+    "exampleIdentifiers": "14, 01",
     "languages": [
       "en"
     ]

--- a/lists/bj/bj-coa.json
+++ b/lists/bj/bj-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BJ/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "20, 10",
+    "exampleIdentifiers": "001, 002",
     "languages": [
       "en"
     ]

--- a/lists/bj/bj-coa.json
+++ b/lists/bj/bj-coa.json
@@ -20,16 +20,21 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Benin.",
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BJ/",
-    "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
-    "languages": []
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "20, 10",
+    "languages": [
+      "en"
+    ]
   },
   "data": {
-    "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BJ/",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/bw/bw-coa.json
+++ b/lists/bw/bw-coa.json
@@ -20,16 +20,21 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Botswana.",
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/BW/",
-    "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
-    "languages": []
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "0100, 0101",
+    "languages": [
+      "en"
+    ]
   },
   "data": {
-    "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/BW/",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/cf/cf-coa.json
+++ b/lists/cf/cf-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CF/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "01, 02 ",
+    "exampleIdentifiers": "01, 02",
     "languages": [
       "en"
     ]

--- a/lists/cg/cg-coa.json
+++ b/lists/cg/cg-coa.json
@@ -20,16 +20,21 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Congo (the).",
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CG/",
-    "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
-    "languages": []
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02",
+    "languages": [
+      "en"
+    ]
   },
   "data": {
-    "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/CG/",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ci/ci-coa.json
+++ b/lists/ci/ci-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CI/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "01, 02",
+    "exampleIdentifiers": "101, 102",
     "languages": [
       "en"
     ]

--- a/lists/ci/ci-coa.json
+++ b/lists/ci/ci-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CI/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "01, 02 ",
+    "exampleIdentifiers": "01, 02",
     "languages": [
       "en"
     ]

--- a/lists/cm/cm-coa.json
+++ b/lists/cm/cm-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/CM/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "01 , 02",
+    "exampleIdentifiers": "01, 02",
     "languages": [
       "en"
     ]

--- a/lists/et/et-coa.json
+++ b/lists/et/et-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ET/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "100, 110",
+    "exampleIdentifiers": "111, 112",
     "languages": [
       "en"
     ]

--- a/lists/gh/gh-coa.json
+++ b/lists/gh/gh-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GH/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "1, 2",
+    "exampleIdentifiers": "001, 002",
     "languages": [
       "en"
     ]

--- a/lists/gm/gm-coa.json
+++ b/lists/gm/gm-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GM/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "01 , 02 ",
+    "exampleIdentifiers": "01, 02",
     "languages": [
       "en"
     ]

--- a/lists/gq/gq-coa.json
+++ b/lists/gq/gq-coa.json
@@ -20,16 +20,21 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Equatorial Guinea.",
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GQ/",
-    "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
-    "languages": []
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02",
+    "languages": [
+      "en"
+    ]
   },
   "data": {
-    "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/GQ/",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/gw/gw-coa.json
+++ b/lists/gw/gw-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/GW/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "1, 6",
+    "exampleIdentifiers": "1, 2",
     "languages": [
       "en"
     ]

--- a/lists/ke/ke-coa.json
+++ b/lists/ke/ke-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KE/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "110, 119",
+    "exampleIdentifiers": "101, 1011",
     "languages": [
       "en"
     ]

--- a/lists/kg/kg-coa.json
+++ b/lists/kg/kg-coa.json
@@ -20,21 +20,16 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Kyrgyzstan.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KG/",
-    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "11, 11",
-    "languages": [
-      "en"
-    ]
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
   },
   "data": {
-    "availability": [
-      "json",
-      "csv"
-    ],
-    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KG/",
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/kh/kh-coa.json
+++ b/lists/kh/kh-coa.json
@@ -20,21 +20,16 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Cambodia.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KH/",
-    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "1, 2",
-    "languages": [
-      "en"
-    ]
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
   },
   "data": {
-    "availability": [
-      "json",
-      "csv"
-    ],
-    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/KH/",
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/kn/kn-coa.json
+++ b/lists/kn/kn-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/KN/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "01, 02 ",
+    "exampleIdentifiers": "01, 02",
     "languages": [
       "en"
     ]

--- a/lists/ma/ma-coa.json
+++ b/lists/ma/ma-coa.json
@@ -20,16 +20,21 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Morocco.",
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MA/",
-    "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
-    "languages": []
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "02, 03",
+    "languages": [
+      "en"
+    ]
   },
   "data": {
-    "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/MA/",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/mg/mg-coa.json
+++ b/lists/mg/mg-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MG/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "01 , 02",
+    "exampleIdentifiers": "01, 02",
     "languages": [
       "en"
     ]

--- a/lists/mw/mw-coa.json
+++ b/lists/mw/mw-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/MW/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "010 , 020 ",
+    "exampleIdentifiers": "010, 020",
     "languages": [
       "en"
     ]

--- a/lists/na/na-coa.json
+++ b/lists/na/na-coa.json
@@ -20,16 +20,21 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Namibia.",
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NA/",
-    "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
-    "languages": []
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02",
+    "languages": [
+      "en"
+    ]
   },
   "data": {
-    "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/NA/",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/ng/ng-coa.json
+++ b/lists/ng/ng-coa.json
@@ -20,16 +20,21 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Nigeria.",
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NG/",
-    "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
-    "languages": []
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "0111, 0112",
+    "languages": [
+      "en"
+    ]
   },
   "data": {
-    "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/NG/",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/nl/nl-coa.json
+++ b/lists/nl/nl-coa.json
@@ -1,6 +1,6 @@
 {
   "name": {
-    "en": "Netherlands (the) Chart of Accounts",
+    "en": "Netherlands (Kingdom of the) Chart of Accounts",
     "local": ""
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/NL/",
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Netherlands (the).",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Netherlands (Kingdom of the).",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/NL/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",

--- a/lists/ph/ph-coa.json
+++ b/lists/ph/ph-coa.json
@@ -20,16 +20,21 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Philippines (the).",
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/PH/",
-    "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
-    "languages": []
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02",
+    "languages": [
+      "en"
+    ]
   },
   "data": {
-    "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/PH/",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/rw/rw-coa.json
+++ b/lists/rw/rw-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/RW/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "01, 02 ",
+    "exampleIdentifiers": "01, 02",
     "languages": [
       "en"
     ]

--- a/lists/sz/sz-coa.json
+++ b/lists/sz/sz-coa.json
@@ -20,16 +20,21 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Eswatini.",
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/SZ/",
-    "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
-    "languages": []
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02",
+    "languages": [
+      "en"
+    ]
   },
   "data": {
-    "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/SZ/",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/tj/tj-coa.json
+++ b/lists/tj/tj-coa.json
@@ -20,21 +20,16 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": true,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
+    "availableOnline": false,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Tajikistan.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TJ/",
-    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "04 , 05 ",
-    "languages": [
-      "en"
-    ]
+    "guidanceOnLocatingIds": "",
+    "exampleIdentifiers": "",
+    "languages": []
   },
   "data": {
-    "availability": [
-      "json",
-      "csv"
-    ],
-    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/TJ/",
+    "availability": [],
+    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/tr/tr-coa.json
+++ b/lists/tr/tr-coa.json
@@ -1,6 +1,6 @@
 {
   "name": {
-    "en": "Turkey Chart of Accounts",
+    "en": "T\u00fcrkiye Chart of Accounts",
     "local": ""
   },
   "url": "https://gov-id-finder.codeforiati.org/countries/TR/",
@@ -21,7 +21,7 @@
   "listType": "secondary",
   "access": {
     "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for Turkey.",
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for T\u00fcrkiye.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TR/",
     "guidanceOnLocatingIds": "",
     "exampleIdentifiers": "",

--- a/lists/tz/tz-coa.json
+++ b/lists/tz/tz-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/TZ/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "02, 03",
+    "exampleIdentifiers": "01, 02",
     "languages": [
       "en"
     ]

--- a/lists/za/za-coa.json
+++ b/lists/za/za-coa.json
@@ -20,16 +20,21 @@
   "deprecated": false,
   "listType": "secondary",
   "access": {
-    "availableOnline": false,
-    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. However, no codes have yet been extracted for South Africa.",
+    "availableOnline": true,
+    "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ZA/",
-    "guidanceOnLocatingIds": "",
-    "exampleIdentifiers": "",
-    "languages": []
+    "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
+    "exampleIdentifiers": "01, 02",
+    "languages": [
+      "en"
+    ]
   },
   "data": {
-    "availability": [],
-    "dataAccessDetails": "Look at the government budget or Chart of Accounts. If you find identifiers, you can also submit them for inclusion to Gov Org ID Finder: https://gov-id-finder.codeforiati.org/about",
+    "availability": [
+      "json",
+      "csv"
+    ],
+    "dataAccessDetails": "A download of the data is available from https://gov-id-finder.codeforiati.org/countries/ZA/",
     "features": [],
     "licenseStatus": "no_license",
     "licenseDetails": ""

--- a/lists/zm/zm-coa.json
+++ b/lists/zm/zm-coa.json
@@ -24,7 +24,7 @@
     "onlineAccessDetails": "Codes can be found in the government budget or Chart of Accounts. Gov Org ID Finder extracts and makes some of these codes available for the convenience of users. The authoritative source remains the government's budget or Chart of Accounts.",
     "publicDatabase": "https://gov-id-finder.codeforiati.org/countries/ZM/",
     "guidanceOnLocatingIds": "The codes from the Organisation or Administrative classification should be used. ",
-    "exampleIdentifiers": "01 , 02 ",
+    "exampleIdentifiers": "01, 02",
     "languages": [
       "en"
     ]


### PR DESCRIPTION
Updates to COA codelists from [Gov ID Finder](https://gov-id-finder.codeforiati.org/)

Includes:
* Updates to a range of codes to ensure they include leading zeroes, where relevant
* Removal of whitespace before and after codes
* Added codes for: Benin, Botswana, Congo (Rep.), Equatorial Guinea, Morocco, Namibia, Nigeria, Philippines, Swaziland, South Africa
* Removed codes for: Cambodia, Kyrgyzstan, Tajikistan - these are not available on gov-id-finder because there were issues with the source data
* Names of Netherlands and Turkey have been updated