### PR TITLE
Corrected CUIT Format Description: ar-cuit.json

### DIFF
--- a/lists/ar/ar-cuit.json
+++ b/lists/ar/ar-cuit.json
@@ -5,7 +5,7 @@
   },
   "url": "",
   "description": {
-    "en": "Any citizen or company starting an economic activity in Argentina must register with the AFIP (Federal Administration of Public Revenues) and receive a Unique Tax Identification Code (CUIT). \n\nThis is an 11 digit number, consisting two digits, hyphen, nine digits, and a one digit checksum. \n"
+    "en": "Any citizen or company starting an economic activity in Argentina must register with the AFIP (Federal Administration of Public Revenues) and receive a Unique Tax Identification Code (CUIT). \n\nThis is an 11 digit number, consisting two digits, hyphen, eight digits, and a one digit checksum. \n"
   },
   "coverage": [
     "AR"


### PR DESCRIPTION
Change description from 9 to 8 digits

This PR updates the description of the **CUIT** (Unique Tax Identification Code) format for Argentina in our documentation. The previous description incorrectly stated that the **CUIT** contains nine digits in the middle section. The correct format is:

- Two digits (prefix indicating the entity type)
- Hyphen
- Eight digits (unique identification number)
- Hyphen
- One digit (checksum)
- Example: `XX-XXXXXXXX-X`

This change ensures accuracy in the documentation and aligns with Argentina's **official CUIT format.**