### PR TITLE
Create tr-vkn.json

### DIFF
--- a/lists/tr/tr-vkn.json
+++ b/lists/tr/tr-vkn.json
@@ -1,6 +1,6 @@
 {
   "name": {
-    "en": "Türkiye Tax Identification Number (Vergi Kimlik Numarası, VKN)",
+    "en": "Tax Identification Number (VKN), Türkiye",
     "local": "Vergi Kimlik Numarası"
   },
   "url": "https://www.gib.gov.tr/",


### PR DESCRIPTION
- Add Türkiye (TR-VKN): Tax Identification Number

Adds a new list for Türkiye covering the Tax Identification Number (Vergi Kimlik Numarası, VKN) issued by the Turkish Revenue Administration (GİB).
