### PR TITLE
Create ls-hei.json

### DIFF
--- a/lists/ls/ls-hei.json
+++ b/lists/ls/ls-hei.json
@@ -15,7 +15,7 @@
     "company",
     "charity"
   ],
-  "sector": [],
+  "sector": ["education"],
   "code": "LS-HEI",
   "confirmed": true,
   "deprecated": false,

--- a/lists/ls/ls-hei.json
+++ b/lists/ls/ls-hei.json
@@ -1,0 +1,49 @@
+{
+  "name": {
+    "en": "Lesotho Higher Education Institution Registration Number (HEI)",
+    "local": "HEI Registration Number"
+  },
+  "url": "https://www.education.gov.ls/",
+  "description": {
+    "en": "Higher Education Institution (HEI) Registration Numbers are issued by the Ministry of Education and Training of the Kingdom of Lesotho. These identifiers are assigned to institutions registered under the Higher Education Act, 2004, as confirmed in official registration certificates issued by the Ministry. HEI numbers are used for accreditation, compliance, and regulatory oversight of institutions offering higher education programmes in Lesotho."
+  },
+  "coverage": [
+    "LS"
+  ],
+  "subnationalCoverage": [],
+  "structure":  [
+    "company",
+    "charity"
+  ],
+  "sector": [],
+  "code": "LS-HEI",
+  "confirmed": true,
+  "deprecated": false,
+  "listType": "secondary",
+  "access": {
+    "availableOnline": false,
+    "onlineAccessDetails": null,
+    "publicDatabase": "",
+    "guidanceOnLocatingIds": "The HEI registration number appears on official registration certificates issued by the Ministry of Education and Training under the Higher Education Act, 2004.",
+    "exampleIdentifiers": "HEI/CRL-2025CNT/3182004",
+    "languages": [
+      "en"
+    ]
+  },
+  "data": {
+    "availability": [],
+    "dataAccessDetails": "HEI registration numbers are issued and maintained by the Ministry of Education and Training and recorded on institutional registration certificates.",
+    "features": [],
+    "licenseStatus": "no_license",
+    "licenseDetails": ""
+  },
+  "meta": {
+    "source": "Registration certificate issued by the Ministry of Education and Training, Kingdom of Lesotho",
+    "lastUpdated": "2025-11-26"
+  },
+  "links": {
+    "opencorporates": "",
+    "wikipedia": "https://en.wikipedia.org/wiki/Education_in_Lesotho"
+  },
+  "formerPrefixes": []
+}

--- a/lists/ls/ls-hei.json
+++ b/lists/ls/ls-hei.json
@@ -25,7 +25,7 @@
     "onlineAccessDetails": null,
     "publicDatabase": "",
     "guidanceOnLocatingIds": "The HEI registration number appears on official registration certificates issued by the Ministry of Education and Training under the Higher Education Act, 2004.",
-    "exampleIdentifiers": "HEI/CRL-2025CNT/3182004",
+    "exampleIdentifiers": "HEI-CRL-2025CNT-3182004",
     "languages": [
       "en"
     ]

--- a/lists/ls/ls-hei.json
+++ b/lists/ls/ls-hei.json
@@ -24,7 +24,7 @@
     "availableOnline": false,
     "onlineAccessDetails": null,
     "publicDatabase": "",
-    "guidanceOnLocatingIds": "The HEI registration number appears on official registration certificates issued by the Ministry of Education and Training under the Higher Education Act, 2004.",
+    "guidanceOnLocatingIds": "The HEI registration number appears on official registration certificates issued by the Ministry of Education and Training under the Higher Education Act, 2004. For use as an identifier, replace any forward slashes, '/', in the registration number with dashes, '-'. See the example.",
     "exampleIdentifiers": "HEI-CRL-2025CNT-3182004",
     "languages": [
       "en"


### PR DESCRIPTION
Added new Lesotho Higher Education Institution (HEI) registry to org-id, classified as a secondary identifier issued by the Ministry of Education and Training.