### PR TITLE
adding commas in between example identifiers

### DIFF
--- a/lists/co/co-nit.json
+++ b/lists/co/co-nit.json
@@ -27,7 +27,7 @@
     "onlineAccessDetails": null,
     "publicDatabase": "https://www.rues.org.co",
     "guidanceOnLocatingIds": "Users can search for companies by name. A successful search will return basic information about the company, such as its legal form and purpose as well as the NIT. Many Colombian companies publish their NIT on their website.\n\n",
-    "exampleIdentifiers": "830008886 830033206 890900943",
+    "exampleIdentifiers": "830008886, 830033206, 890900943",
     "languages": [
       "es"
     ]


### PR DESCRIPTION
At the moment the example identifiers all run in to each other as "CO-NIT-830008886830033206890900943" 